### PR TITLE
Fix long-dictation truncation on the SFSpeechRecognizer fallback (Intel)

### DIFF
--- a/Sources/Services/LegacyTranscriptionService.swift
+++ b/Sources/Services/LegacyTranscriptionService.swift
@@ -1,23 +1,82 @@
 import Speech
 import AVFoundation
 
-/// Fallback for when the modern `SpeechTranscriber` doesn't support the current
-/// locale or its model asset can't be installed. Forced on-device.
+/// Fallback transcriber used when the modern `SpeechTranscriber` can't run
+/// (Intel Macs, or a locale with no installed model). Forced on-device.
+///
+/// `SFSpeechRecognizer` is built for short utterances. For long continuous
+/// audio its hypothesis "slides" — it keeps only a bounded window of recent
+/// speech and drops earlier words — and it stops after roughly a minute.
+/// Reading the latest hypothesis alone therefore loses the beginning of a long
+/// dictation. Instead we accumulate finalized text and start a fresh
+/// recognition request whenever the current one finalizes or nears the limit,
+/// stitching the segments into one transcript.
+///
+/// All mutable state is confined to `queue`; the recognition callback, audio
+/// feed, and finish all hop onto it, so there is a single owner of the state.
 final class LegacyTranscriptionService: StreamingTranscriber {
     var onPartial: ((String) -> Void)?
 
+    private let queue = DispatchQueue(label: "com.frigade.yap.legacy-transcriber")
     private var recognizer: SFSpeechRecognizer?
     private var request: SFSpeechAudioBufferRecognitionRequest?
     private var task: SFSpeechRecognitionTask?
-    private var latest = ""
+
+    private var committed = ""
+    private var current = ""
+    private var finished = false
+    private var segmentFrames: AVAudioFrameCount = 0
+
+    /// Roll to a new request before SFSpeechRecognizer's ~1 minute ceiling, so a
+    /// long dictation is never dropped or slid away.
+    private let segmentSeconds: Double = 40
 
     func begin(locale: Locale) async throws {
-        latest = ""
-
         guard let recognizer = SFSpeechRecognizer(locale: locale) ?? SFSpeechRecognizer() else {
             throw TranscriptionError.setupFailed
         }
-        self.recognizer = recognizer
+        queue.sync {
+            self.recognizer = recognizer
+            self.committed = ""
+            self.current = ""
+            self.finished = false
+        }
+        queue.async { self.startSegment() }
+    }
+
+    func feed(_ buffer: AVAudioPCMBuffer) {
+        queue.async {
+            guard !self.finished, let request = self.request else { return }
+            request.append(buffer)
+            self.segmentFrames += buffer.frameLength
+            let rate = buffer.format.sampleRate
+            if rate > 0, Double(self.segmentFrames) / rate >= self.segmentSeconds {
+                self.rollSegment()
+            }
+        }
+    }
+
+    func finish() async throws -> String {
+        queue.sync {
+            finished = true
+            request?.endAudio()
+        }
+        // Give the recognizer a moment to emit its last result.
+        try? await Task.sleep(nanoseconds: 400_000_000)
+        return queue.sync {
+            task?.finish()
+            let text = join(committed, current).trimmingCharacters(in: .whitespacesAndNewlines)
+            request = nil
+            task = nil
+            recognizer = nil
+            return text
+        }
+    }
+
+    // MARK: - Private (all invoked on `queue`)
+
+    private func startSegment() {
+        guard let recognizer, !finished else { return }
 
         let request = SFSpeechAudioBufferRecognitionRequest()
         request.shouldReportPartialResults = true
@@ -25,28 +84,45 @@ final class LegacyTranscriptionService: StreamingTranscriber {
             request.requiresOnDeviceRecognition = true
         }
         self.request = request
+        current = ""
+        segmentFrames = 0
 
-        task = recognizer.recognitionTask(with: request) { [weak self] result, _ in
-            guard let self, let result else { return }
-            self.latest = result.bestTranscription.formattedString
-            self.onPartial?(self.latest)
+        task = recognizer.recognitionTask(with: request) { [weak self] result, error in
+            guard let self else { return }
+            self.queue.async {
+                if let result {
+                    self.current = result.bestTranscription.formattedString
+                    self.onPartial?(self.join(self.committed, self.current))
+                    if result.isFinal { self.commitAndContinue() }
+                } else if error != nil {
+                    // The segment ended (limit reached, or an error). Keep what we
+                    // have and roll into a fresh request.
+                    self.commitAndContinue()
+                }
+            }
         }
     }
 
-    func feed(_ buffer: AVAudioPCMBuffer) {
-        request?.append(buffer)
+    /// Finalize the current request. Its final result triggers `commitAndContinue`.
+    private func rollSegment() {
+        guard !finished else { return }
+        request?.endAudio()
     }
 
-    func finish() async throws -> String {
-        request?.endAudio()
-        // Give the recognizer a brief moment to emit the last result.
-        try? await Task.sleep(nanoseconds: 300_000_000)
-        task?.finish()
+    private func commitAndContinue() {
+        let segment = current.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !segment.isEmpty {
+            committed = join(committed, segment)
+        }
+        current = ""
+        if !finished {
+            startSegment()
+        }
+    }
 
-        let result = latest.trimmingCharacters(in: .whitespacesAndNewlines)
-        request = nil
-        task = nil
-        recognizer = nil
-        return result
+    private func join(_ a: String, _ b: String) -> String {
+        if a.isEmpty { return b }
+        if b.isEmpty { return a }
+        return a + " " + b
     }
 }


### PR DESCRIPTION
### The bug
On Intel Macs, dictating more than a paragraph comes back truncated to just the last few sentences.

### Cause
`SpeechAnalyzer`'s on-device models are Apple-Silicon-oriented, so on Intel `TranscriptionService.isSupported` returns false and Yap falls back to `SFSpeechRecognizer` (`LegacyTranscriptionService`). That recognizer is built for short utterances: for long continuous audio it keeps only a **bounded window of recent speech** (its `bestTranscription.formattedString` slides, dropping earlier words) and it stops after roughly a minute.

The old code did `latest = result.bestTranscription.formattedString` on every callback — it *replaced* rather than accumulated, so once the recognizer's window slid past the opening, the beginning was gone. That's exactly "only the last few sentences."

### Fix
Rewrite `LegacyTranscriptionService` to:
- **Accumulate** finalized text instead of replacing it.
- **Roll to a fresh recognition request** whenever the current one finalizes, errors, or crosses ~40s of audio (staying under the recognizer's ceiling), stitching the segments into one transcript.
- Confine all mutable state to one serial queue, so the audio feed, recognition callback, and `finish()` share a single owner (no data races across those threads).

The modern `SpeechAnalyzer` path (Apple Silicon) already accumulates correctly and is **untouched**, so day-to-day use on Apple Silicon is unaffected.

### Testing
Builds clean and the existing suite passes (22/22). The state machine and stores are covered, but `LegacyTranscriptionService` wraps `SFSpeechRecognizer`, which needs the real system, so **this needs a check on an Intel Mac**: dictate several paragraphs and confirm the whole thing comes back, including the opening. A word may occasionally clip at a ~40s segment boundary; that's the tradeoff for unbounded length, and it beats losing everything before the last few sentences.