### PR TITLE
Resolve the user's locale to one the speech engines actually support

### DIFF
--- a/Sources/Services/DictationSession.swift
+++ b/Sources/Services/DictationSession.swift
@@ -18,19 +18,34 @@ final class DictationSession: DictationSessioning {
     private var transcriber: StreamingTranscriber?
     private let locale: Locale
 
+    /// Which engine to use and the locale to run it with. The two engines
+    /// support different locale sets and neither takes `Locale.current`
+    /// verbatim, so they are resolved together.
+    enum Engine {
+        case modern(Locale)
+        case legacy(Locale)
+    }
+
     /// Resolved once — querying supported locales is slow enough to be felt on
     /// the first keypress.
-    private static var cachedModernSupport: Bool?
+    private static var cachedEngine: Engine?
 
     init(locale: Locale = .current) {
         self.locale = locale
     }
 
+    static func resolveEngine(for locale: Locale) async -> Engine {
+        if let modern = await TranscriptionService.resolvedLocale(for: locale) {
+            return .modern(modern)
+        }
+        return .legacy(LegacyTranscriptionService.resolvedLocale(for: locale) ?? locale)
+    }
+
     static func prewarm(locale: Locale = .current) async {
-        let supported = await TranscriptionService.isSupported(locale: locale)
-        cachedModernSupport = supported
-        guard supported else { return }
-        await TranscriptionService.prepareModel(for: locale)
+        let engine = await resolveEngine(for: locale)
+        cachedEngine = engine
+        guard case .modern(let resolved) = engine else { return }
+        await TranscriptionService.prepareModel(for: resolved)
     }
 
     func start() async throws {
@@ -46,17 +61,24 @@ final class DictationSession: DictationSessioning {
         }
         try capture.start()
 
-        let supportsModern: Bool
-        if let cached = Self.cachedModernSupport {
-            supportsModern = cached
+        let resolved: Engine
+        if let cached = Self.cachedEngine {
+            resolved = cached
         } else {
-            supportsModern = await TranscriptionService.isSupported(locale: locale)
-            Self.cachedModernSupport = supportsModern
+            resolved = await Self.resolveEngine(for: locale)
+            Self.cachedEngine = resolved
         }
 
-        let engine: StreamingTranscriber = supportsModern
-            ? TranscriptionService()
-            : LegacyTranscriptionService()
+        let engine: StreamingTranscriber
+        let engineLocale: Locale
+        switch resolved {
+        case .modern(let locale):
+            engine = TranscriptionService()
+            engineLocale = locale
+        case .legacy(let locale):
+            engine = LegacyTranscriptionService()
+            engineLocale = locale
+        }
 
         engine.onPartial = { [weak self] text in
             Task { @MainActor in self?.onPartial?(text) }
@@ -64,7 +86,7 @@ final class DictationSession: DictationSessioning {
         transcriber = engine
 
         do {
-            try await engine.begin(locale: locale)
+            try await engine.begin(locale: engineLocale)
         } catch {
             capture.stop()
             relay.reset()

--- a/Sources/Services/LegacyTranscriptionService.swift
+++ b/Sources/Services/LegacyTranscriptionService.swift
@@ -31,8 +31,19 @@ final class LegacyTranscriptionService: StreamingTranscriber {
     /// long dictation is never dropped or slid away.
     private let segmentSeconds: Double = 40
 
+    /// The locale this recognizer can actually run, or nil if none fits.
+    static func resolvedLocale(for locale: Locale) -> Locale? {
+        SpeechLocale.bestMatch(for: locale, in: SFSpeechRecognizer.supportedLocales())
+    }
+
     func begin(locale: Locale) async throws {
-        guard let recognizer = SFSpeechRecognizer(locale: locale) ?? SFSpeechRecognizer() else {
+        // `SFSpeechRecognizer(locale:)` returns a recognizer for locales it does
+        // not support and even reports `isAvailable == true`; it only fails once
+        // a task starts, and that failure looks exactly like a segment ending,
+        // so we would retry forever and return an empty transcript. Resolve to a
+        // locale it lists as supported before constructing it.
+        let resolved = Self.resolvedLocale(for: locale).flatMap(SFSpeechRecognizer.init(locale:))
+        guard let recognizer = resolved ?? SFSpeechRecognizer() else {
             throw TranscriptionError.setupFailed
         }
         queue.sync {

--- a/Sources/Services/SpeechLocale.swift
+++ b/Sources/Services/SpeechLocale.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Maps the user's locale onto one a speech engine actually supports.
+///
+/// `Locale.current` cannot be handed to a speech API verbatim. When the system
+/// language and region disagree — English (US) with the region set to Spain,
+/// say — macOS represents that as `en_US@rg=eszzzz`, which serializes to BCP-47
+/// as `en-US-u-rg-eszzzz`. No engine lists that string among its supported
+/// locales, so comparing identifiers exactly concludes the language is
+/// unsupported even though `en-US` is right there with its model installed.
+///
+/// Matching therefore widens in three steps: the exact tag, then the same
+/// language and region ignoring extensions, then the same language in any
+/// region.
+enum SpeechLocale {
+    static func bestMatch<Candidates: Sequence>(
+        for locale: Locale,
+        in candidates: Candidates
+    ) -> Locale? where Candidates.Element == Locale {
+        // `supportedLocales` is unordered, so sort to keep the widened matches
+        // stable from one launch to the next.
+        let ordered = candidates.sorted { $0.identifier(.bcp47) < $1.identifier(.bcp47) }
+
+        if let exact = ordered.first(where: { $0.identifier(.bcp47) == locale.identifier(.bcp47) }) {
+            return exact
+        }
+
+        guard let language = locale.language.languageCode?.identifier else { return nil }
+
+        // `locale.language.region`, not `locale.region`: the latter reports the
+        // regional override (ES in the example above) rather than the region of
+        // the language being spoken (US).
+        if let region = locale.language.region?.identifier,
+           let regional = ordered.first(where: {
+               $0.language.languageCode?.identifier == language
+                   && $0.language.region?.identifier == region
+           }) {
+            return regional
+        }
+
+        return ordered.first { $0.language.languageCode?.identifier == language }
+    }
+}

--- a/Sources/Services/TranscriptionService.swift
+++ b/Sources/Services/TranscriptionService.swift
@@ -12,11 +12,15 @@ final class TranscriptionService: StreamingTranscriber {
     private var analyzerFormat: AVAudioFormat?
     private var finalized = ""
 
+    /// The supported locale to transcribe `locale` with, or nil if this engine
+    /// covers none of it. The returned locale is what must be handed to
+    /// `SpeechTranscriber` — `locale` itself may carry extensions it rejects.
+    static func resolvedLocale(for locale: Locale) async -> Locale? {
+        SpeechLocale.bestMatch(for: locale, in: await SpeechTranscriber.supportedLocales)
+    }
+
     static func isSupported(locale: Locale) async -> Bool {
-        let supported = await SpeechTranscriber.supportedLocales
-        return supported
-            .map { $0.identifier(.bcp47) }
-            .contains(locale.identifier(.bcp47))
+        await resolvedLocale(for: locale) != nil
     }
 
     func begin(locale: Locale) async throws {

--- a/Tests/SpeechLocaleTests.swift
+++ b/Tests/SpeechLocaleTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+@testable import Yap
+
+struct SpeechLocaleTests {
+    private let english = [
+        Locale(identifier: "en-AU"),
+        Locale(identifier: "en-GB"),
+        Locale(identifier: "en-US"),
+        Locale(identifier: "es-ES"),
+    ]
+
+    @Test func exactTagWins() {
+        #expect(SpeechLocale.bestMatch(for: Locale(identifier: "en-GB"), in: english)?
+            .identifier(.bcp47) == "en-GB")
+    }
+
+    /// The case that broke dictation outright: system language English (US) with
+    /// the region set to Spain. The regional override makes the BCP-47 tag
+    /// `en-US-u-rg-eszzzz`, which matches no supported locale exactly.
+    @Test func regionalOverrideResolvesToSpokenRegion() {
+        let overridden = Locale(identifier: "en_US@rg=eszzzz")
+        // Guard the fixture: the bug only exists because of this serialization.
+        #expect(overridden.identifier(.bcp47) == "en-US-u-rg-eszzzz")
+
+        #expect(SpeechLocale.bestMatch(for: overridden, in: english)?
+            .identifier(.bcp47) == "en-US")
+    }
+
+    @Test func fallsBackToSameLanguageInAnotherRegion() {
+        #expect(SpeechLocale.bestMatch(for: Locale(identifier: "en-ZA"), in: english)?
+            .identifier(.bcp47) == "en-AU")
+    }
+
+    @Test func widenedMatchIsStableRegardlessOfCandidateOrder() {
+        let forward = SpeechLocale.bestMatch(for: Locale(identifier: "en-ZA"), in: english)
+        let reversed = SpeechLocale.bestMatch(for: Locale(identifier: "en-ZA"), in: english.reversed())
+        #expect(forward?.identifier(.bcp47) == reversed?.identifier(.bcp47))
+    }
+
+    @Test func unsupportedLanguageHasNoMatch() {
+        #expect(SpeechLocale.bestMatch(for: Locale(identifier: "ja-JP"), in: english) == nil)
+    }
+
+    @Test func emptyCandidatesHaveNoMatch() {
+        #expect(SpeechLocale.bestMatch(for: Locale(identifier: "en-US"), in: [Locale]()) == nil)
+    }
+}


### PR DESCRIPTION

Fixes #5.

`Locale.current` is not safe to hand to a speech API verbatim. When the system
language and region disagree — English (US) with Region set to Spain — macOS
represents it as `en_US@rg=eszzzz`, which serialises to BCP-47 as
`en-US-u-rg-eszzzz`. `TranscriptionService.isSupported(locale:)` compared that
string exactly against `SpeechTranscriber.supportedLocales`, which lists `en-US`
and never the extended form, so the modern engine was reported unavailable even
with the `en-US` model installed.

Dictation then fell to `LegacyTranscriptionService` and broke there too, because
it received the same locale. `SFSpeechRecognizer(locale:)` returns a recognizer
for locales it does not support and reports `isAvailable == true`, so the
existing `?? SFSpeechRecognizer()` fallback never engaged; the failure only
surfaced once a task started, where it is indistinguishable from a segment
ending, so `commitAndContinue()` restarted the segment indefinitely and
`finish()` returned an empty string. The user saw a working waveform and no text.

## What this changes

A new `SpeechLocale.bestMatch(for:in:)` widens matching in three steps: the exact
BCP-47 tag, then the same language and region ignoring `-u-` extensions, then the
same language in any region. Both engines now resolve through it and are handed
the locale they matched on, rather than the raw one:

- `TranscriptionService.resolvedLocale(for:)` returns the supported locale to
  construct `SpeechTranscriber` with; `isSupported(locale:)` is now defined in
  terms of it.
- `LegacyTranscriptionService.resolvedLocale(for:)` does the same against
  `SFSpeechRecognizer.supportedLocales()`, so the recognizer is only built for a
  locale it lists.
- `DictationSession` caches an `Engine` enum carrying both the choice and its
  resolved locale, so the resolution happens once and `prewarm()` reserves the
  model for the locale that will actually be used.

Candidates are sorted before matching because `supportedLocales` is unordered,
which would otherwise make the widened match vary between launches.

`locale.language.region` is used rather than `locale.region` deliberately: on the
locale above the latter returns `ES` (the regional override) instead of `US`, and
matching on it would transcribe English speech with the Spanish model.

## Tests

`Tests/SpeechLocaleTests.swift` covers the exact-tag case, the regional-override
regression, both widening steps, order-independence, and the no-match cases. The
regression test asserts the BCP-47 fixture is faithful first, so it cannot pass
for the wrong reason if Foundation ever normalises the identifier differently.

## Verification note

I could not build the app to confirm this end to end: I have no Xcode on this
machine, and Command Line Tools ships no `SwiftDataMacros` plugin, so
`Sources/Models/Transcript.swift` cannot compile outside Xcode. What I did verify:

- the patched sources typecheck with `swiftc -typecheck`,
- `Tests/SpeechLocaleTests.swift` passes under swift-testing (6/6),
- against the live Speech framework on the affected machine, the old exact match
  returns `false` for `Locale.current` while `bestMatch` resolves it to `en-US`,
  which is present in both `supportedLocales` and `installedLocales` — so this
  moves the affected configuration onto the modern engine rather than the broken
  fallback.

Worth a run on a machine with Xcode before merging, and I'd be glad to adjust if
you'd rather solve it another way — a language picker would subsume this, though
I think the locale should still be normalised before it reaches either engine.
