### PR TITLE
Add offline transcription CLI

### DIFF
--- a/CLITests/CLIArgumentsTests.swift
+++ b/CLITests/CLIArgumentsTests.swift
@@ -1,0 +1,93 @@
+import Testing
+
+struct CLIArgumentsTests {
+    @Test func emptyArgumentsShowHelp() throws {
+        #expect(try CLIArguments.parse([]) == .help)
+    }
+
+    @Test func barePathTranscribesWithDefaults() throws {
+        #expect(
+            try CLIArguments.parse(["meeting.m4a"])
+                == .transcribe(
+                    path: "meeting.m4a",
+                    options: CLITranscriptionOptions()
+                )
+        )
+    }
+
+    @Test func explicitTranscribeAcceptsOptionsInAnyOrder() throws {
+        #expect(
+            try CLIArguments.parse([
+                "--locale", "en-US",
+                "transcript.wav",
+                "--output", "transcript.txt"
+            ])
+                == .transcribe(
+                    path: "transcript.wav",
+                    options: CLITranscriptionOptions(
+                        localeIdentifier: "en-US",
+                        outputPath: "transcript.txt"
+                    )
+                )
+        )
+    }
+
+    @Test func recordAcceptsFractionalDuration() throws {
+        #expect(
+            try CLIArguments.parse([
+                "record", "--duration", "1.5", "-l", "en-GB"
+            ])
+                == .record(
+                    options: CLITranscriptionOptions(
+                        localeIdentifier: "en-GB",
+                        outputPath: nil
+                    ),
+                    duration: 1.5
+                )
+        )
+    }
+
+    @Test func localesListsModels() throws {
+        #expect(try CLIArguments.parse(["locales"]) == .locales)
+    }
+
+    @Test func doubleDashAllowsLeadingDashInFileName() throws {
+        #expect(
+            try CLIArguments.parse(["--", "-recording.wav"])
+                == .transcribe(
+                    path: "-recording.wav",
+                    options: CLITranscriptionOptions()
+                )
+        )
+    }
+
+    @Test func missingOptionValueFails() {
+        #expect(throws: CLIArgumentError.missingValue("--locale")) {
+            try CLIArguments.parse(["record", "--locale"])
+        }
+    }
+
+    @Test func invalidDurationFails() {
+        #expect(throws: CLIArgumentError.invalidDuration("0")) {
+            try CLIArguments.parse(["record", "--duration", "0"])
+        }
+    }
+
+    @Test func durationIsRejectedForFiles() {
+        #expect(throws: CLIArgumentError.durationRequiresRecord) {
+            try CLIArguments.parse(["audio.wav", "--duration", "5"])
+        }
+    }
+
+    @Test func multipleFilesFail() {
+        #expect(throws: CLIArgumentError.tooManyAudioFiles) {
+            try CLIArguments.parse(["first.wav", "second.wav"])
+        }
+    }
+
+    @Test func positionalArgumentIsRejectedForRecord() {
+        #expect(throws: CLIArgumentError.unexpectedArgument("audio.wav")) {
+            try CLIArguments.parse(["record", "audio.wav"])
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -53,6 +53,37 @@ Yap into your Applications folder.
 
 Released builds are signed and notarized, so macOS opens them without complaint.
 
+### Command-line utility
+
+The repository also includes a `yap` command for transcribing audio files or the default
+microphone. Its final transcript goes to standard output, so it works naturally in scripts:
+
+```bash
+yap meeting.m4a
+yap record
+yap record --duration 30 > transcript.txt
+yap transcribe interview.wav --locale en-US --output interview.txt
+```
+
+The CLI is stricter than the menu-bar app: it only uses the modern `SpeechTranscriber` and
+only when the requested model is already installed. It never invokes Apple's model downloader
+and never falls back to a recognizer that might use the network. Run `yap locales` to list the
+on-device models available on your Mac.
+
+Build and install it from source:
+
+```bash
+brew install xcodegen
+xcodegen generate
+xcodebuild -project Yap.xcodeproj -scheme YapCLI -configuration Release \
+  -destination 'platform=macOS' -derivedDataPath .build build
+mkdir -p "$HOME/.local/bin"
+cp .build/Build/Products/Release/yap "$HOME/.local/bin/yap"
+```
+
+Make sure `$HOME/.local/bin` is on your `PATH`. File transcription needs no privacy
+permissions. The first `yap record` asks for microphone access.
+
 ## Why we built this
 
 There's no shortage of voice to text tools for macOS, and some of the open source ones are
@@ -92,6 +123,7 @@ anything that's quicker to say than type.
 - Pastes straight into the focused field of whatever app you were in
 - Local transcript history with search, copy, and delete
 - Live waveform and partial transcript while you speak
+- Optional CLI for audio files, scripted recording, and standard-output pipelines
 - Press escape twice to discard a dictation in progress
 - Follows your system default microphone, including when it changes mid-session
 - Optional launch at login, off by default

--- a/Sources/CLI/CLIArguments.swift
+++ b/Sources/CLI/CLIArguments.swift
@@ -1,0 +1,146 @@
+import Foundation
+
+struct CLITranscriptionOptions: Equatable {
+    var localeIdentifier: String?
+    var outputPath: String?
+}
+
+enum CLICommand: Equatable {
+    case transcribe(path: String, options: CLITranscriptionOptions)
+    case record(options: CLITranscriptionOptions, duration: Double?)
+    case locales
+    case help
+    case version
+}
+
+enum CLIArgumentError: LocalizedError, Equatable {
+    case missingValue(String)
+    case invalidDuration(String)
+    case unsupportedOption(String)
+    case unexpectedArgument(String)
+    case missingAudioFile
+    case tooManyAudioFiles
+    case durationRequiresRecord
+
+    var errorDescription: String? {
+        switch self {
+        case .missingValue(let option):
+            return "\(option) requires a value"
+        case .invalidDuration(let value):
+            return "invalid duration '\(value)'; expected a number greater than zero"
+        case .unsupportedOption(let option):
+            return "unknown option '\(option)'"
+        case .unexpectedArgument(let argument):
+            return "unexpected argument '\(argument)'"
+        case .missingAudioFile:
+            return "missing audio file"
+        case .tooManyAudioFiles:
+            return "expected exactly one audio file"
+        case .durationRequiresRecord:
+            return "--duration is only valid with 'record'"
+        }
+    }
+}
+
+enum CLIArguments {
+    static func parse(_ arguments: [String]) throws -> CLICommand {
+        guard !arguments.isEmpty else { return .help }
+
+        var remaining = arguments
+        let mode: Mode
+
+        switch remaining.first {
+        case "transcribe":
+            mode = .transcribe
+            remaining.removeFirst()
+        case "record":
+            mode = .record
+            remaining.removeFirst()
+        case "locales":
+            guard remaining.count == 1 else {
+                throw CLIArgumentError.unexpectedArgument(remaining[1])
+            }
+            return .locales
+        case "help", "--help", "-h":
+            return .help
+        case "version", "--version":
+            return .version
+        default:
+            mode = .transcribe
+        }
+
+        var options = CLITranscriptionOptions()
+        var duration: Double?
+        var positionals: [String] = []
+        var index = 0
+
+        while index < remaining.count {
+            let argument = remaining[index]
+
+            switch argument {
+            case "--help", "-h":
+                return .help
+            case "--version":
+                return .version
+            case "--locale", "-l":
+                options.localeIdentifier = try value(after: argument, in: remaining, index: &index)
+            case "--output", "-o":
+                options.outputPath = try value(after: argument, in: remaining, index: &index)
+            case "--duration":
+                let rawValue = try value(after: argument, in: remaining, index: &index)
+                guard let parsed = Double(rawValue), parsed.isFinite, parsed > 0 else {
+                    throw CLIArgumentError.invalidDuration(rawValue)
+                }
+                duration = parsed
+            case "--":
+                positionals.append(contentsOf: remaining.dropFirst(index + 1))
+                index = remaining.count
+                continue
+            default:
+                if argument.hasPrefix("-") {
+                    throw CLIArgumentError.unsupportedOption(argument)
+                }
+                positionals.append(argument)
+            }
+
+            index += 1
+        }
+
+        switch mode {
+        case .transcribe:
+            guard duration == nil else {
+                throw CLIArgumentError.durationRequiresRecord
+            }
+            guard !positionals.isEmpty else {
+                throw CLIArgumentError.missingAudioFile
+            }
+            guard positionals.count == 1 else {
+                throw CLIArgumentError.tooManyAudioFiles
+            }
+            return .transcribe(path: positionals[0], options: options)
+        case .record:
+            guard positionals.isEmpty else {
+                throw CLIArgumentError.unexpectedArgument(positionals[0])
+            }
+            return .record(options: options, duration: duration)
+        }
+    }
+
+    private enum Mode {
+        case transcribe
+        case record
+    }
+
+    private static func value(
+        after option: String,
+        in arguments: [String],
+        index: inout Int
+    ) throws -> String {
+        let valueIndex = index + 1
+        guard valueIndex < arguments.count else {
+            throw CLIArgumentError.missingValue(option)
+        }
+        index = valueIndex
+        return arguments[valueIndex]
+    }
+}

--- a/Sources/CLI/OfflineTranscriber.swift
+++ b/Sources/CLI/OfflineTranscriber.swift
@@ -1,0 +1,205 @@
+import AVFoundation
+import Foundation
+import Speech
+
+enum OfflineTranscriptionError: LocalizedError {
+    case unavailable
+    case unsupportedLocale(String)
+    case modelNotInstalled(String)
+    case modelReservationFailed(String, Error)
+    case invalidAudioFormat
+    case microphonePermissionDenied
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable:
+            return "Apple's on-device SpeechTranscriber is unavailable on this Mac"
+        case .unsupportedLocale(let identifier):
+            return "SpeechTranscriber does not support locale '\(identifier)'"
+        case .modelNotInstalled(let identifier):
+            return """
+            the on-device model for '\(identifier)' is not installed; install that \
+            dictation language in macOS first, then run 'yap locales'
+            """
+        case .modelReservationFailed(let identifier, let error):
+            return "could not reserve the installed '\(identifier)' model: \(error.localizedDescription)"
+        case .invalidAudioFormat:
+            return "the installed speech model does not accept the microphone's audio format"
+        case .microphonePermissionDenied:
+            return "microphone access was denied; allow access in System Settings > Privacy & Security > Microphone"
+        }
+    }
+}
+
+enum OfflineTranscriber {
+    static func installedLocaleIdentifiers() async -> [String] {
+        guard SpeechTranscriber.isAvailable else { return [] }
+        return await SpeechTranscriber.installedLocales
+            .map(bcp47Identifier)
+            .sorted()
+    }
+
+    static func transcribeFile(
+        at url: URL,
+        localeIdentifier: String?
+    ) async throws -> String {
+        let locale = try await resolveInstalledLocale(localeIdentifier)
+        let audioFile = try AVAudioFile(forReading: url)
+        let transcriber = SpeechTranscriber(locale: locale, preset: .transcription)
+        let analyzer = SpeechAnalyzer(modules: [transcriber])
+        let resultsTask = collectResults(from: transcriber)
+
+        do {
+            let lastSampleTime = try await analyzer.analyzeSequence(from: audioFile)
+            if let lastSampleTime {
+                try await analyzer.finalizeAndFinish(through: lastSampleTime)
+            } else {
+                await analyzer.cancelAndFinishNow()
+            }
+            return try await resultsTask.value
+        } catch {
+            await analyzer.cancelAndFinishNow()
+            resultsTask.cancel()
+            _ = try? await resultsTask.value
+            throw error
+        }
+    }
+
+    static func record(
+        localeIdentifier: String?,
+        onReady: (String) -> Void,
+        waitUntilStop: () async -> Void
+    ) async throws -> String {
+        try await requireMicrophoneAccess()
+
+        let locale = try await resolveInstalledLocale(localeIdentifier)
+        let transcriber = SpeechTranscriber(locale: locale, preset: .progressiveTranscription)
+        let analyzer = SpeechAnalyzer(modules: [transcriber])
+
+        guard let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(
+            compatibleWith: [transcriber]
+        ) else {
+            throw OfflineTranscriptionError.invalidAudioFormat
+        }
+
+        let (inputs, continuation) = AsyncStream<AnalyzerInput>.makeStream()
+        let resultsTask = collectResults(from: transcriber)
+        try await analyzer.start(inputSequence: inputs)
+
+        let converter = BufferConverter()
+        let capture = AudioCaptureService()
+        capture.onBuffer = { buffer in
+            guard let converted = try? converter.convertBuffer(buffer, to: analyzerFormat) else {
+                return
+            }
+            continuation.yield(AnalyzerInput(buffer: converted))
+        }
+
+        do {
+            try capture.start()
+        } catch {
+            continuation.finish()
+            await analyzer.cancelAndFinishNow()
+            resultsTask.cancel()
+            _ = try? await resultsTask.value
+            throw error
+        }
+
+        onReady(bcp47Identifier(locale))
+        await waitUntilStop()
+
+        capture.stop()
+        continuation.finish()
+
+        do {
+            try await analyzer.finalizeAndFinishThroughEndOfInput()
+            return try await resultsTask.value
+        } catch {
+            await analyzer.cancelAndFinishNow()
+            resultsTask.cancel()
+            _ = try? await resultsTask.value
+            throw error
+        }
+    }
+
+    private static func resolveInstalledLocale(_ identifier: String?) async throws -> Locale {
+        guard SpeechTranscriber.isAvailable else {
+            throw OfflineTranscriptionError.unavailable
+        }
+
+        let requested = identifier.map(Locale.init(identifier:)) ?? .current
+        guard let supported = await SpeechTranscriber.supportedLocale(equivalentTo: requested) else {
+            throw OfflineTranscriptionError.unsupportedLocale(
+                identifier ?? bcp47Identifier(requested)
+            )
+        }
+
+        let supportedIdentifier = bcp47Identifier(supported)
+        let installed = await SpeechTranscriber.installedLocales
+        guard let locale = installed.first(where: {
+            bcp47Identifier($0).caseInsensitiveCompare(supportedIdentifier) == .orderedSame
+        }) else {
+            throw OfflineTranscriptionError.modelNotInstalled(supportedIdentifier)
+        }
+
+        let reserved = await AssetInventory.reservedLocales
+        if !reserved.contains(where: {
+            bcp47Identifier($0).caseInsensitiveCompare(supportedIdentifier) == .orderedSame
+        }) {
+            do {
+                try await AssetInventory.reserve(locale: locale)
+            } catch {
+                throw OfflineTranscriptionError.modelReservationFailed(
+                    supportedIdentifier,
+                    error
+                )
+            }
+        }
+
+        let probe = SpeechTranscriber(locale: locale, preset: .transcription)
+        guard await AssetInventory.status(forModules: [probe]) == .installed else {
+            throw OfflineTranscriptionError.modelNotInstalled(supportedIdentifier)
+        }
+
+        return locale
+    }
+
+    private static func collectResults(
+        from transcriber: SpeechTranscriber
+    ) -> Task<String, Error> {
+        Task {
+            var finalized = ""
+            var volatile = ""
+
+            for try await result in transcriber.results {
+                let text = String(result.text.characters)
+                if result.isFinal {
+                    finalized += text
+                    volatile = ""
+                } else {
+                    volatile = text
+                }
+            }
+
+            return (finalized + volatile)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+    }
+
+    private static func requireMicrophoneAccess() async throws {
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .authorized:
+            return
+        case .notDetermined:
+            guard await AVCaptureDevice.requestAccess(for: .audio) else {
+                throw OfflineTranscriptionError.microphonePermissionDenied
+            }
+        default:
+            throw OfflineTranscriptionError.microphonePermissionDenied
+        }
+    }
+
+    private static func bcp47Identifier(_ locale: Locale) -> String {
+        locale.identifier(.bcp47)
+    }
+}

--- a/Sources/CLI/YapCLI.swift
+++ b/Sources/CLI/YapCLI.swift
@@ -1,0 +1,147 @@
+import Darwin
+import Foundation
+
+@main
+enum YapCLI {
+    static func main() async {
+        do {
+            let command = try CLIArguments.parse(Array(CommandLine.arguments.dropFirst()))
+            try await run(command)
+        } catch let error as CLIArgumentError {
+            writeError("yap: \(error.localizedDescription)\nTry 'yap --help' for usage.")
+            exit(2)
+        } catch {
+            writeError("yap: \(error.localizedDescription)")
+            exit(1)
+        }
+    }
+
+    private static func run(_ command: CLICommand) async throws {
+        switch command {
+        case .transcribe(let path, let options):
+            let url = try audioFileURL(for: path)
+            let transcript = try await OfflineTranscriber.transcribeFile(
+                at: url,
+                localeIdentifier: options.localeIdentifier
+            )
+            try write(transcript, to: options.outputPath)
+
+        case .record(let options, let duration):
+            let transcript = try await OfflineTranscriber.record(
+                localeIdentifier: options.localeIdentifier,
+                onReady: { locale in
+                    if let duration {
+                        writeError("Recording with \(locale) for \(format(duration)) seconds…")
+                    } else {
+                        writeError("Recording with \(locale). Press Return to stop.")
+                    }
+                },
+                waitUntilStop: {
+                    if let duration {
+                        try? await Task.sleep(for: .seconds(duration))
+                    } else {
+                        _ = await Task.detached { readLine() }.value
+                    }
+                }
+            )
+            try write(transcript, to: options.outputPath)
+
+        case .locales:
+            let locales = await OfflineTranscriber.installedLocaleIdentifiers()
+            if locales.isEmpty {
+                throw OfflineTranscriptionError.unavailable
+            }
+            writeStandardOutput(locales.joined(separator: "\n"))
+
+        case .help:
+            writeStandardOutput(help)
+
+        case .version:
+            writeStandardOutput("yap \(version)")
+        }
+    }
+
+    private static func audioFileURL(for path: String) throws -> URL {
+        let expanded = NSString(string: path).expandingTildeInPath
+        let url = URL(fileURLWithPath: expanded).standardizedFileURL
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory),
+              !isDirectory.boolValue
+        else {
+            throw CLIFileError.notFound(path)
+        }
+        return url
+    }
+
+    private static func write(_ transcript: String, to outputPath: String?) throws {
+        guard let outputPath, outputPath != "-" else {
+            writeStandardOutput(transcript)
+            return
+        }
+
+        let expanded = NSString(string: outputPath).expandingTildeInPath
+        let url = URL(fileURLWithPath: expanded).standardizedFileURL
+        let contents = transcript + "\n"
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    private static func writeStandardOutput(_ text: String) {
+        let terminated = text.hasSuffix("\n") ? text : text + "\n"
+        FileHandle.standardOutput.write(Data(terminated.utf8))
+    }
+
+    private static func writeError(_ text: String) {
+        let terminated = text.hasSuffix("\n") ? text : text + "\n"
+        FileHandle.standardError.write(Data(terminated.utf8))
+    }
+
+    private static func format(_ duration: Double) -> String {
+        duration.rounded() == duration
+            ? String(Int(duration))
+            : String(duration)
+    }
+
+    private static var version: String {
+        Bundle.main.object(
+            forInfoDictionaryKey: "CFBundleShortVersionString"
+        ) as? String ?? "development"
+    }
+
+    private static let help = """
+    Usage:
+      yap [options] <audio-file>
+      yap transcribe [options] <audio-file>
+      yap record [options]
+      yap locales
+
+    Transcribe an audio file:
+      yap meeting.m4a
+      yap transcribe interview.wav --locale en-US
+
+    Record from the default microphone:
+      yap record
+      yap record --duration 30 > transcript.txt
+
+    Options:
+      -l, --locale <identifier>  BCP-47 locale (defaults to the system locale)
+      -o, --output <path>       Write the transcript to a file instead of stdout
+          --duration <seconds>  Stop recording after this many seconds
+      -h, --help                Show this help
+          --version             Show the version
+
+    Yap uses only Apple SpeechTranscriber models already installed on this Mac.
+    It never downloads a model and never falls back to cloud transcription.
+    Run 'yap locales' to list the available on-device models.
+    """
+}
+
+private enum CLIFileError: LocalizedError {
+    case notFound(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notFound(let path):
+            return "audio file not found: \(path)"
+        }
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -25,6 +25,8 @@ targets:
     platform: macOS
     sources:
       - path: Sources
+        excludes:
+          - CLI
     dependencies:
       - package: KeyboardShortcuts
     settings:
@@ -38,6 +40,24 @@ targets:
         LD_RUNPATH_SEARCH_PATHS:
           - "@executable_path/../Frameworks"
 
+  YapCLI:
+    type: tool
+    platform: macOS
+    sources:
+      - path: Sources/CLI
+      - path: Sources/Services/AudioCaptureService.swift
+      - path: Sources/Services/AudioLevel.swift
+      - path: Sources/Services/BufferConverter.swift
+    settings:
+      base:
+        PRODUCT_NAME: yap
+        PRODUCT_BUNDLE_IDENTIFIER: com.frigade.YapCLI
+        GENERATE_INFOPLIST_FILE: YES
+        CREATE_INFOPLIST_SECTION_IN_BINARY: YES
+        INFOPLIST_KEY_NSMicrophoneUsageDescription: Yap uses the microphone only while recording an on-device transcription.
+        CODE_SIGN_STYLE: Manual
+        CODE_SIGN_IDENTITY: "-"
+
   YapTests:
     type: bundle.unit-test
     platform: macOS
@@ -50,6 +70,17 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.frigade.YapTests
         GENERATE_INFOPLIST_FILE: YES
 
+  YapCLITests:
+    type: bundle.unit-test
+    platform: macOS
+    sources:
+      - path: CLITests/CLIArgumentsTests.swift
+      - path: Sources/CLI/CLIArguments.swift
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.frigade.YapCLITests
+        GENERATE_INFOPLIST_FILE: YES
+
 schemes:
   Yap:
     build:
@@ -59,3 +90,12 @@ schemes:
     test:
       targets:
         - YapTests
+
+  YapCLI:
+    build:
+      targets:
+        YapCLI: all
+        YapCLITests: [test]
+    test:
+      targets:
+        - YapCLITests


### PR DESCRIPTION
## Summary

- add a `YapCLI` target that transcribes audio files or the default microphone
- keep final text on stdout, with optional file output, locale selection, timed recording, and installed-locale discovery
- require an already-installed `SpeechTranscriber` model; the CLI never invokes `AssetInstallationRequest` and never falls back to `SFSpeechRecognizer`
- document source installation and add focused argument-parser tests

## Why

This follows up on [the Hacker News request for a scriptable, fully on-device interface](https://news.ycombinator.com/item?id=49079385). It makes Yap's Apple Speech transcription useful from shell scripts while retaining a strict offline execution path.

## Examples

```sh
yap meeting.m4a
yap record
yap record --duration 30 > transcript.txt
yap transcribe interview.wav --locale en-US --output interview.txt
yap locales
```

## Validation

- `xcodebuild -project Yap.xcodeproj -scheme YapCLI -destination 'platform=macOS' test` (11 tests)
- `xcodebuild -project Yap.xcodeproj -scheme Yap -destination 'platform=macOS' test` (22 existing tests)
- Release build using the README command
- end-to-end file transcription using a locally synthesized AIFF
- end-to-end one-second microphone transcription
