### PR TITLE
Add a dictation language picker

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -26,6 +26,22 @@ final class AppState {
         }
     }
 
+    /// "system" follows the OS locale; otherwise a BCP-47 identifier.
+    var dictationLanguage: String {
+        didSet {
+            UserDefaults.standard.set(dictationLanguage, forKey: "dictationLanguage")
+            applyDictationLocale()
+        }
+    }
+
+    private(set) var availableLocales: [Locale] = []
+
+    var effectiveDictationLocale: Locale {
+        dictationLanguage == Self.systemLanguage ? .current : Locale(identifier: dictationLanguage)
+    }
+
+    static let systemLanguage = "system"
+
     private(set) var coordinator: RecordingCoordinator!
 
     private let hotkeys = HotkeyManager()
@@ -36,6 +52,7 @@ final class AppState {
     private let sounds = SystemSoundPlayer()
     private let deviceObserver = DefaultInputObserver()
     private var history: HistoryStore!
+    private let dictation: DictationSession
 
     private init() {
         do {
@@ -50,13 +67,20 @@ final class AppState {
         ) ?? .none
         currentInputName = AudioDevices.defaultInputName()
 
+        let language = UserDefaults.standard.string(forKey: "dictationLanguage") ?? Self.systemLanguage
+        let dictation = DictationSession(
+            locale: language == Self.systemLanguage ? .current : Locale(identifier: language)
+        )
+        self.dictation = dictation
+        dictationLanguage = language
+
         let history = HistoryStore(context: modelContainer.mainContext)
         self.history = history
 
         sounds.enabled = { [weak self] in self?.soundsEnabled ?? true }
 
         coordinator = RecordingCoordinator(
-            session: DictationSession(locale: .current),
+            session: dictation,
             injector: injector,
             history: history,
             hud: hud,
@@ -93,14 +117,35 @@ final class AppState {
         // Build the HUD window and resolve the speech model up front, so the
         // first press of the shortcut is immediate rather than paying setup cost.
         hud.prepare()
+        let locale = effectiveDictationLocale
         Task.detached(priority: .utility) {
-            await DictationSession.prewarm()
+            await DictationSession.prewarm(locale: locale)
+        }
+
+        Task { [weak self] in
+            let locales = await TranscriptionService.availableLocales()
+            self?.availableLocales = locales.sorted {
+                Self.languageName(for: $0).localizedCaseInsensitiveCompare(Self.languageName(for: $1)) == .orderedAscending
+            }
         }
 
         // Delivered on the main queue by the observer, so assign directly.
         deviceObserver.start { [weak self] name in
             self?.currentInputName = name
         }
+    }
+
+    private func applyDictationLocale() {
+        let locale = effectiveDictationLocale
+        dictation.setLocale(locale)
+        Task.detached(priority: .utility) {
+            await DictationSession.prewarm(locale: locale)
+        }
+    }
+
+    static func languageName(for locale: Locale) -> String {
+        Locale.current.localizedString(forIdentifier: locale.identifier(.bcp47))
+            ?? locale.identifier(.bcp47)
     }
 
     func toggleRecording() {

--- a/Sources/Services/DictationSession.swift
+++ b/Sources/Services/DictationSession.swift
@@ -16,7 +16,7 @@ final class DictationSession: DictationSessioning {
     private let capture = AudioCaptureService()
     private let relay = AudioBufferRelay()
     private var transcriber: StreamingTranscriber?
-    private let locale: Locale
+    private var locale: Locale
 
     /// Which engine to use and the locale to run it with. The two engines
     /// support different locale sets and neither takes `Locale.current`
@@ -32,6 +32,14 @@ final class DictationSession: DictationSessioning {
 
     init(locale: Locale = .current) {
         self.locale = locale
+    }
+
+    /// Switch dictation language while idle. Clears the resolved-engine cache so
+    /// the next recording re-resolves for the new locale.
+    func setLocale(_ newLocale: Locale) {
+        locale = newLocale
+        transcriber = nil
+        Self.cachedEngine = nil
     }
 
     static func resolveEngine(for locale: Locale) async -> Engine {

--- a/Sources/Services/TranscriptionService.swift
+++ b/Sources/Services/TranscriptionService.swift
@@ -23,6 +23,10 @@ final class TranscriptionService: StreamingTranscriber {
         await resolvedLocale(for: locale) != nil
     }
 
+    static func availableLocales() async -> [Locale] {
+        await SpeechTranscriber.supportedLocales
+    }
+
     func begin(locale: Locale) async throws {
         finalized = ""
 

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -10,6 +10,7 @@ struct SettingsView: View {
             VStack(alignment: .leading, spacing: Theme.s5) {
                 historySection
                 shortcutSection
+                languageSection
                 generalSection
                 inputSection
                 permissionsSection
@@ -88,6 +89,37 @@ struct SettingsView: View {
                     .padding(.horizontal, Theme.s3)
                     .padding(.vertical, Theme.s2 + 2)
                 }
+            }
+        }
+    }
+
+    private var languageSection: some View {
+        @Bindable var app = app
+        return VStack(alignment: .leading, spacing: Theme.s3) {
+            SectionLabel("Language")
+            Card(padding: Theme.s2) {
+                HStack(spacing: Theme.s3) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Dictation language").font(.system(size: 13, weight: .medium))
+                        Text("Dictate in a language other than your system's.")
+                            .font(.system(size: 12)).foregroundStyle(.secondary)
+                    }
+                    Spacer(minLength: Theme.s3)
+                    Picker("", selection: $app.dictationLanguage) {
+                        Text("System default").tag(AppState.systemLanguage)
+                        if !app.availableLocales.isEmpty {
+                            Divider()
+                            ForEach(app.availableLocales, id: \.identifier) { locale in
+                                Text(AppState.languageName(for: locale))
+                                    .tag(locale.identifier(.bcp47))
+                            }
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(width: 168)
+                }
+                .padding(.horizontal, Theme.s3)
+                .padding(.vertical, Theme.s2 + 2)
             }
         }
     }


### PR DESCRIPTION
Closes #2.

Adds a Language picker in Settings so you can dictate in a language other than the one your Mac is set to. The list comes from the locales the on-device transcriber supports; the choice is persisted and overrides `Locale.current`, defaulting to the system language.

Built on the locale resolution from #6, so a picked language that needs a model downloads it on first use.