### PR TITLE
Enable "hiding" macOS dock icon

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -17,6 +17,14 @@ final class AppState {
         didSet { UserDefaults.standard.set(soundsEnabled, forKey: "soundsEnabled") }
     }
 
+    // Whether the app's icon is shown in the macOS Dock.
+    var showDockIcon: Bool {
+        didSet {
+            UserDefaults.standard.set(showDockIcon, forKey: "showDockIcon")
+            NSApp.setActivationPolicy(showDockIcon ? .regular : .accessory)
+        }
+    }
+
     var mainPage: MainPage = .settings
 
     var modifierTrigger: ModifierTrigger {
@@ -45,6 +53,7 @@ final class AppState {
         }
 
         soundsEnabled = (UserDefaults.standard.object(forKey: "soundsEnabled") as? Bool) ?? true
+        showDockIcon = (UserDefaults.standard.object(forKey: "showDockIcon") as? Bool) ?? true
         modifierTrigger = ModifierTrigger(
             rawValue: UserDefaults.standard.string(forKey: "modifierTrigger") ?? ""
         ) ?? .none

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -112,6 +112,12 @@ struct SettingsView: View {
                         subtitle: "Play a cue when recording starts and stops.",
                         isOn: $app.soundsEnabled
                     )
+                    Divider().overlay(Theme.hairline).padding(.horizontal, Theme.s3)
+                    SettingsToggleRow(
+                        title: "Show icon in the macOS Dock",
+                        subtitle: "Show Yap in the Dock while it's running.",
+                        isOn: $app.showDockIcon
+                    )
                 }
             }
         }

--- a/Sources/YapApp.swift
+++ b/Sources/YapApp.swift
@@ -44,9 +44,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // A relaunch briefly leaves the previous instance alive.
         AppRelauncher.terminateOtherInstances()
 
-        NSApp.setActivationPolicy(.regular)
-
         let app = AppState.shared
+        NSApp.setActivationPolicy(app.showDockIcon ? .regular : .accessory)
         app.bootstrap()
 
         if !app.permissions.allGranted {


### PR DESCRIPTION
_👋 hi this is all human-written text etc._

I really like Yap! Very nice macOS utility, feels great that I can set it up for quick-dictation in a bunch of places. Thanks for making it & sharing it!

One thing that I like in macOS utility apps like this is the ability to hide the macOS dock icon, so it doesn't clutter-up the Dock or the App Switcher.

Here's the change to its behavior - the dock icon can now be hidden when that new switch is changed to "off". There's a new switch in Yap's settings to control it.
| New setting is "on" (default behavior)  | New setting is "off" | Settings screen |
| ------------- | ------------- | ------ |
| <img width="680" height="482" alt="CleanShot 2026-07-28 at 10 25 13@2x" src="https://github.com/user-attachments/assets/bf19daae-b9f3-4cb4-a800-6519532a76a7" />  | <img width="680" height="482" alt="CleanShot 2026-07-28 at 10 25 38@2x" src="https://github.com/user-attachments/assets/7514db2d-2de9-47b4-bf26-dbbfa58748f9" />  | <img width="1728" height="2352" alt="CleanShot 2026-07-28 at 10 23 06@2x" src="https://github.com/user-attachments/assets/636e296f-6e98-4a3c-8e91-cfd99c474abf" /> | 

I see other folks have raised this in GitHub issues #3 and #7 - fixed here!
