### PR TITLE
Add a Show in Dock toggle

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -26,6 +26,13 @@ final class AppState {
         }
     }
 
+    var showInDock: Bool {
+        didSet {
+            UserDefaults.standard.set(showInDock, forKey: "showInDock")
+            applyDockVisibility()
+        }
+    }
+
     /// "system" follows the OS locale; otherwise a BCP-47 identifier.
     var dictationLanguage: String {
         didSet {
@@ -62,6 +69,7 @@ final class AppState {
         }
 
         soundsEnabled = (UserDefaults.standard.object(forKey: "soundsEnabled") as? Bool) ?? true
+        showInDock = (UserDefaults.standard.object(forKey: "showInDock") as? Bool) ?? true
         modifierTrigger = ModifierTrigger(
             rawValue: UserDefaults.standard.string(forKey: "modifierTrigger") ?? ""
         ) ?? .none
@@ -90,6 +98,7 @@ final class AppState {
     }
 
     func bootstrap() {
+        applyDockVisibility()
         permissions.refresh()
         launchAtLogin.refresh()
 
@@ -133,6 +142,10 @@ final class AppState {
         deviceObserver.start { [weak self] name in
             self?.currentInputName = name
         }
+    }
+
+    private func applyDockVisibility() {
+        NSApp.setActivationPolicy(showInDock ? .regular : .accessory)
     }
 
     private func applyDictationLocale() {

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -140,6 +140,12 @@ struct SettingsView: View {
                     )
                     Divider().overlay(Theme.hairline).padding(.horizontal, Theme.s3)
                     SettingsToggleRow(
+                        title: "Show in Dock",
+                        subtitle: "Turn off to run from the menu bar only.",
+                        isOn: $app.showInDock
+                    )
+                    Divider().overlay(Theme.hairline).padding(.horizontal, Theme.s3)
+                    SettingsToggleRow(
                         title: "Sound feedback",
                         subtitle: "Play a cue when recording starts and stops.",
                         isOn: $app.soundsEnabled

--- a/Sources/YapApp.swift
+++ b/Sources/YapApp.swift
@@ -44,8 +44,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // A relaunch briefly leaves the previous instance alive.
         AppRelauncher.terminateOtherInstances()
 
-        NSApp.setActivationPolicy(.regular)
-
         let app = AppState.shared
         app.bootstrap()
 


### PR DESCRIPTION
Closes #3. Closes #7.

Adds a **Show in Dock** toggle in Settings, on by default. Turn it off and Yap becomes a menu-bar-only accessory app, applied live with no restart. The menu bar item is always present, so settings and quit are reachable whichever way you run it.

This gives people who want a clean Dock a way out, without taking the Dock icon away from those who rely on it.