### PR TITLE
Remove common filler words from every transcript

### DIFF
--- a/Sources/Coordinator/RecordingCoordinator.swift
+++ b/Sources/Coordinator/RecordingCoordinator.swift
@@ -140,11 +140,18 @@ final class RecordingCoordinator {
                 return
             }
 
-            // Deterministic dictionary pass first: instant, on device, catches
-            // first-letter mis-hearings like "brigade" -> "Frigade".
+            // Deterministic passes first: instant, on device, no model needed.
+            text = FillerRemoval.strip(text)
             let terms = vocabulary()
             if !terms.isEmpty {
                 text = DictionaryCorrection.correctFirstLetterMisses(in: text, terms: terms)
+            }
+
+            // Removing fillers can empty a transcript that was only "um uh".
+            guard !text.isEmpty else {
+                hud.hide(after: 0)
+                state = .idle
+                return
             }
 
             // Cleanup also applies the dictionary to messier mis-hearings. If you

--- a/Sources/Services/FillerRemoval.swift
+++ b/Sources/Services/FillerRemoval.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Strips common filler words ("um", "uh", ...) from a transcript with a plain
+/// regex. Deterministic and on device, so it costs nothing and can be on by
+/// default. The heavier Apple Intelligence cleanup does this too, but this runs
+/// even when that is off.
+enum FillerRemoval {
+    /// The default filler set. Whole-word and case-insensitive, so real words
+    /// that merely contain these letters ("human", "summary") are left alone.
+    static let words = ["uhhh", "uhh", "uhm", "umm", "mmm", "hmm", "ehh", "uh", "um", "hm", "mm", "mh"]
+
+    static func strip(_ text: String) -> String {
+        let alternation = words
+            .map { NSRegularExpression.escapedPattern(for: $0) }
+            .joined(separator: "|")
+
+        // Remove each filler token as a whole word, taking a trailing comma with it.
+        var out = text.replacingOccurrences(
+            of: "\\b(?:\(alternation))\\b,?",
+            with: "",
+            options: [.regularExpression, .caseInsensitive]
+        )
+
+        // Nothing matched: leave the transcript exactly as it was, so filler-free
+        // dictations aren't re-spaced or re-capitalized.
+        guard out != text else { return text }
+
+        // Tidy the gaps the removals leave behind.
+        out = out.replacingOccurrences(of: "[ \\t]{2,}", with: " ", options: .regularExpression)
+        out = out.replacingOccurrences(of: ",\\s*,", with: ",", options: .regularExpression)
+        out = out.replacingOccurrences(of: "\\s+([,.!?;:])", with: "$1", options: .regularExpression)
+        out = out.replacingOccurrences(of: "([,.!?;:])\\1+", with: "$1", options: .regularExpression)
+        out = out.replacingOccurrences(of: "^[\\s,]+", with: "", options: .regularExpression)
+        out = out.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return capitalizeSentences(out)
+    }
+
+    /// Uppercase the first letter, and the first letter after each sentence end,
+    /// so removing a leading "Um" doesn't leave the sentence starting lowercase.
+    /// Never lowercases anything that was already capital.
+    private static func capitalizeSentences(_ text: String) -> String {
+        var chars = Array(text)
+        var capitalizeNext = true
+        for i in chars.indices {
+            let c = chars[i]
+            if capitalizeNext, c.isLetter {
+                chars[i] = Character(c.uppercased())
+                capitalizeNext = false
+            } else if ".!?".contains(c) {
+                capitalizeNext = true
+            } else if !c.isWhitespace {
+                capitalizeNext = false
+            }
+        }
+        return String(chars)
+    }
+}

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -208,7 +208,7 @@ struct SettingsView: View {
                     SettingsToggleRow(
                         title: "Clean up transcripts",
                         subtitle: app.cleanup.isAvailable
-                            ? "Remove filler words and format lists with Apple Intelligence, on-device."
+                            ? "Fix punctuation, format lists, and apply spoken corrections with Apple Intelligence, on-device."
                             : "Requires Apple Intelligence, enabled in System Settings.",
                         isOn: $app.cleanupEnabled
                     )

--- a/Tests/FillerRemovalTests.swift
+++ b/Tests/FillerRemovalTests.swift
@@ -1,0 +1,44 @@
+import Testing
+@testable import Yap
+
+struct FillerRemovalTests {
+    private func strip(_ text: String) -> String { FillerRemoval.strip(text) }
+
+    @Test func removesLeadingFillerAndCapitalizes() {
+        #expect(strip("um so I think") == "So I think")
+    }
+
+    @Test func removesMidSentenceFiller() {
+        #expect(strip("I think um we should go") == "I think we should go")
+    }
+
+    @Test func removesFillerWithCommas() {
+        #expect(strip("so, um, yeah") == "So, yeah")
+    }
+
+    @Test func removesSeveralDifferentFillers() {
+        #expect(strip("uh hello uhh there hmm") == "Hello there")
+    }
+
+    @Test func isCaseInsensitive() {
+        #expect(strip("Um okay UH sure") == "Okay sure")
+    }
+
+    @Test func leavesRealWordsThatContainFillerLetters() {
+        // "human" contains "um", "summary" contains "umm" — both must survive, and
+        // with no filler removed the text is returned untouched (not re-capitalized).
+        #expect(strip("the human summary") == "the human summary")
+    }
+
+    @Test func capitalizesAfterSentenceEnd() {
+        #expect(strip("yeah. um okay") == "Yeah. Okay")
+    }
+
+    @Test func doesNotLowercaseExistingCapitals() {
+        #expect(strip("um I met Anna today") == "I met Anna today")
+    }
+
+    @Test func allFillerBecomesEmpty() {
+        #expect(strip("um uh hmm") == "")
+    }
+}

--- a/Tests/RecordingCoordinatorTests.swift
+++ b/Tests/RecordingCoordinatorTests.swift
@@ -247,7 +247,8 @@ struct RecordingCoordinatorTests {
         await coordinator.toggle()
         await coordinator.toggle()
 
-        #expect(cleaner.cleaned == ["um so hello world"])
+        // Fillers are stripped deterministically before the model sees the text.
+        #expect(cleaner.cleaned == ["So hello world"])
         #expect(injector.delivered == ["Hello world."])
         #expect(history.saved == ["Hello world."])
         #expect(hud.phases.contains(.cleaning))


### PR DESCRIPTION
Strips the common fillers (um, uh, uhm, umm, uhh, uhhh, hmm, hm, mmm, mm, mh, ehh) from every dictation with a deterministic, on-device regex. No model, no setting, always on.

It removes each filler as a whole word (so "human" and "summary" survive), takes a trailing comma with it, collapses the leftover spacing, and re-capitalizes only when it removed a leading filler. A transcript with no fillers is returned untouched. Runs before the optional Apple Intelligence cleanup, so there's no conflict.

61 tests pass, including 9 for the stripper.