### PR TITLE
Hide the Dock icon when the Settings window closes

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -76,6 +76,7 @@ final class AppState {
     let cleanup = TranscriptCleanupService()
     private let deviceObserver = DefaultInputObserver()
     private var history: HistoryStore!
+    private var windowCloseObserver: NSObjectProtocol?
     private let dictation: DictationSession
 
     private init() {
@@ -125,6 +126,7 @@ final class AppState {
 
     func bootstrap() {
         applyDockVisibility()
+        observeWindowClosesForDockVisibility()
         permissions.refresh()
         launchAtLogin.refresh()
 
@@ -180,6 +182,21 @@ final class AppState {
 
     private func applyDockVisibility() {
         NSApp.setActivationPolicy(showInDock ? .regular : .accessory)
+    }
+
+    /// Flipping the policy to `.accessory` does not drop the Dock icon while a
+    /// window is still on screen, so turning off "Show in Dock" from Settings
+    /// leaves the icon until the window closes. Re-assert the policy once a window
+    /// closes so closing Settings actually hides it.
+    private func observeWindowClosesForDockVisibility() {
+        windowCloseObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                guard let self, !self.showInDock else { return }
+                self.applyDockVisibility()
+            }
+        }
     }
 
     private func applyDictationLocale() {


### PR DESCRIPTION
Closes #22 (thanks @eltoncrego).

Turning off Show in Dock while Settings is open flips the activation policy to `.accessory`, but macOS keeps the Dock icon on screen as long as a window is visible, and nothing re-applied the policy afterward. So the icon lingered until you toggled the setting again.

Fix: re-assert the activation policy when a window closes (only when Show in Dock is off), so closing Settings actually hides the icon. 61 tests pass.