### PR TITLE
Feature: per language shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ https://github.com/user-attachments/assets/9bd8dae6-49d6-4c06-98b9-878e24dd401f
 
 Yap lives in your menu bar and waits for a shortcut. Trigger it and a small window appears near the bottom of the screen with a live waveform and a running preview of what you have said so far. Press the shortcut again and the text gets pasted into the app you were already working in. Every transcript is saved locally, so you can go back and copy something again later.
 
-The default shortcut is `⌘⇧D`. You can rebind it, or set a single modifier key instead. Tapping right shift on its own works nicely if you have a spare thumb.
+The default shortcut is `⌘⇧D`. You can rebind it, or set a single modifier key instead. Tapping right shift on its own works nicely if you have a spare thumb. If you dictate in more than one language, give each one its own shortcut in Settings.
 
 ## Install
 
@@ -66,6 +66,7 @@ So Yap ships no model at all. It's roughly three thousand lines of native Swift 
 
 - On-device transcription through Apple's Speech framework
 - Global shortcut, fully rebindable, with optional single-modifier triggers like right shift
+- A shortcut per dictation language, so the key you press picks the language
 - Pastes straight into the focused field of whatever app you were in
 - Local transcript history with search, copy, and delete
 - Live waveform and partial transcript while you speak
@@ -119,7 +120,7 @@ No. There is no network code in the app at all. Transcription runs entirely on d
 
 There is not much of one, and that is on purpose. Yap does a single thing, and keeping it small enough that you never have to think about it is the main design principle. Most feature ideas make an app like this worse.
 
-We are not precious about it though. If something is missing that you would use every day, open an issue or send a pull request and we will give it a fair hearing. A language picker is the most likely next addition, since Yap follows your system locale today.
+We are not precious about it though. If something is missing that you would use every day, open an issue or send a pull request and we will give it a fair hearing.
 
 ## Development
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import KeyboardShortcuts
 import Observation
 import SwiftData
 
@@ -27,20 +28,6 @@ final class AppState {
 
     var mainPage: MainPage = .settings
 
-    var modifierTrigger: ModifierTrigger {
-        didSet {
-            UserDefaults.standard.set(modifierTrigger.rawValue, forKey: "modifierTrigger")
-            modifierHotkeys.trigger = modifierTrigger
-        }
-    }
-
-    var functionKeyTrigger: FunctionKeyTrigger {
-        didSet {
-            UserDefaults.standard.set(functionKeyTrigger.rawValue, forKey: "functionKeyTrigger")
-            functionKeys.trigger = functionKeyTrigger
-        }
-    }
-
     var showInDock: Bool {
         didSet {
             UserDefaults.standard.set(showInDock, forKey: "showInDock")
@@ -48,24 +35,28 @@ final class AppState {
         }
     }
 
-    /// "system" follows the OS locale; otherwise a BCP-47 identifier.
-    var dictationLanguage: String {
-        didSet {
-            UserDefaults.standard.set(dictationLanguage, forKey: "dictationLanguage")
-            applyDictationLocale()
-        }
-    }
-
     private(set) var availableLocales: [Locale] = []
 
-    var effectiveDictationLocale: Locale {
-        dictationLanguage == Self.systemLanguage ? .current : Locale(identifier: dictationLanguage)
-    }
+    /// Each profile is a language and the triggers that start dictation in it, so
+    /// switching from English to German is a different key rather than a visit
+    /// here. There is always at least one.
+    var profiles: [DictationProfile] { profileStore.profiles }
 
-    static let systemLanguage = "system"
+    /// What onboarding should tell the user to press: the first profile's key
+    /// combination, or whichever key it uses instead. Nil when nothing is bound.
+    var firstTriggerDescription: String? {
+        let profile = profiles[0]
+        if let shortcut = KeyboardShortcuts.getShortcut(for: profile.shortcutName) {
+            return "\(shortcut)"
+        }
+        if profile.modifierTrigger != .none { return profile.modifierTrigger.title }
+        if profile.functionKeyTrigger != .none { return profile.functionKeyTrigger.title }
+        return nil
+    }
 
     private(set) var coordinator: RecordingCoordinator!
 
+    private let profileStore = DictationProfileStore()
     private let hotkeys = HotkeyManager()
     private let modifierHotkeys = ModifierHotkeyMonitor()
     private let functionKeys = FunctionKeyMonitor()
@@ -89,20 +80,12 @@ final class AppState {
         soundsEnabled = (UserDefaults.standard.object(forKey: "soundsEnabled") as? Bool) ?? true
         showInDock = (UserDefaults.standard.object(forKey: "showInDock") as? Bool) ?? true
         cleanupEnabled = (UserDefaults.standard.object(forKey: "cleanupEnabled") as? Bool) ?? false
-        modifierTrigger = ModifierTrigger(
-            rawValue: UserDefaults.standard.string(forKey: "modifierTrigger") ?? ""
-        ) ?? .none
-        functionKeyTrigger = FunctionKeyTrigger(
-            rawValue: UserDefaults.standard.string(forKey: "functionKeyTrigger") ?? ""
-        ) ?? .none
         currentInputName = AudioDevices.defaultInputName()
 
-        let language = UserDefaults.standard.string(forKey: "dictationLanguage") ?? Self.systemLanguage
-        let dictation = DictationSession(
-            locale: language == Self.systemLanguage ? .current : Locale(identifier: language)
-        )
+        // Whichever trigger fires picks the language, but something has to be
+        // loaded before the first press — the first profile is the safe guess.
+        let dictation = DictationSession(locale: Self.locale(for: profileStore.profiles[0].language))
         self.dictation = dictation
-        dictationLanguage = language
 
         let history = HistoryStore(context: modelContainer.mainContext)
         self.history = history
@@ -134,23 +117,10 @@ final class AppState {
         // keeps the UI honest the moment the user grants it.
         permissions.startObserving()
 
-        hotkeys.onToggle { [weak self] in
-            guard let self else { return }
-            Task { await self.coordinator.toggle() }
-        }
-
-        modifierHotkeys.onTap = { [weak self] in
-            guard let self else { return }
-            Task { await self.coordinator.toggle() }
-        }
-        modifierHotkeys.trigger = modifierTrigger
+        modifierHotkeys.onTap = { [weak self] id in self?.start(profile: id) }
+        functionKeys.onTap = { [weak self] id in self?.start(profile: id) }
+        applyProfiles()
         modifierHotkeys.start()
-
-        functionKeys.onTap = { [weak self] in
-            guard let self else { return }
-            Task { await self.coordinator.toggle() }
-        }
-        functionKeys.trigger = functionKeyTrigger
         functionKeys.start()
 
         escapeMonitor.onEscape = { [weak self] in
@@ -158,13 +128,9 @@ final class AppState {
         }
         escapeMonitor.start()
 
-        // Build the HUD window and resolve the speech model up front, so the
-        // first press of the shortcut is immediate rather than paying setup cost.
+        // Build the HUD window up front, so the first press of the shortcut is
+        // immediate rather than paying setup cost.
         hud.prepare()
-        let locale = effectiveDictationLocale
-        Task.detached(priority: .utility) {
-            await DictationSession.prewarm(locale: locale)
-        }
 
         Task { [weak self] in
             let locales = await TranscriptionService.availableLocales()
@@ -199,12 +165,60 @@ final class AppState {
         }
     }
 
-    private func applyDictationLocale() {
-        let locale = effectiveDictationLocale
-        dictation.setLocale(locale)
-        Task.detached(priority: .utility) {
-            await DictationSession.prewarm(locale: locale)
+    func addProfile() {
+        profileStore.add()
+        applyProfiles()
+    }
+
+    func removeProfile(_ id: UUID) {
+        guard let profile = profiles.first(where: { $0.id == id }) else { return }
+        profileStore.remove(id)
+        // Only once the store agreed to drop it — it keeps the last profile.
+        if !profiles.contains(where: { $0.id == id }) { hotkeys.forget(profile) }
+        applyProfiles()
+    }
+
+    func updateProfile(_ profile: DictationProfile) {
+        profileStore.update(profile)
+        applyProfiles()
+    }
+
+    /// The shortcut recorder saves itself, so this is only about the effect that
+    /// has on the other profiles.
+    func shortcutChanged(for profile: DictationProfile) {
+        hotkeys.claim(profile, among: profiles)
+    }
+
+    /// Points every monitor at the current profiles and gets each language ready.
+    /// Cheap enough to re-run on any edit, which keeps it the single path.
+    private func applyProfiles() {
+        let profiles = self.profiles
+        hotkeys.bind(profiles) { [weak self] id in self?.start(profile: id) }
+        modifierHotkeys.bindings = profiles.map { ($0.id, $0.modifierTrigger) }
+        functionKeys.bindings = profiles.map { ($0.id, $0.functionKeyTrigger) }
+
+        // Resolving a locale and staging its model is slow enough to be felt on the
+        // first press, so every language a trigger could ask for is warmed now.
+        for locale in Set(profiles.map(\.language)).map(Self.locale(for:)) {
+            Task.detached(priority: .utility) {
+                await DictationSession.prewarm(locale: locale)
+            }
         }
+    }
+
+    /// Starts, or stops, dictation in the profile's language. The language is only
+    /// swapped when a dictation is beginning: a second press is a stop, and moving
+    /// the locale mid-flight would drop the transcriber holding the audio.
+    private func start(profile id: UUID) {
+        guard let profile = profiles.first(where: { $0.id == id }) else { return }
+        if coordinator.state == .idle {
+            dictation.setLocale(Self.locale(for: profile.language))
+        }
+        Task { await coordinator.toggle() }
+    }
+
+    static func locale(for language: String) -> Locale {
+        language == DictationProfile.systemLanguage ? .current : Locale(identifier: language)
     }
 
     static func languageName(for locale: Locale) -> String {
@@ -212,8 +226,9 @@ final class AppState {
             ?? locale.identifier(.bcp47)
     }
 
+    /// The menu bar has no language of its own, so it uses the first profile's.
     func toggleRecording() {
-        Task { await coordinator.toggle() }
+        start(profile: profiles[0].id)
     }
 
     /// Manual restart escape hatch. Never runs mid-dictation — that would throw

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -72,6 +72,7 @@ final class AppState {
     private let deviceObserver = DefaultInputObserver()
     private var history: HistoryStore!
     private var windowCloseObserver: NSObjectProtocol?
+    private var recorderFocusObserver: NSObjectProtocol?
     private let dictation: DictationSession
     /// The profile the current dictation started in, which is what the HUD names.
     private var activeProfile: DictationProfile
@@ -122,6 +123,7 @@ final class AppState {
     func bootstrap() {
         applyDockVisibility()
         observeWindowClosesForDockVisibility()
+        observeRecorderFocus()
         permissions.refresh()
         launchAtLogin.refresh()
 
@@ -155,6 +157,28 @@ final class AppState {
         // Delivered on the main queue by the observer, so assign directly.
         deviceObserver.start { [weak self] name in
             self?.currentInputName = name
+        }
+    }
+
+    /// KeyboardShortcuts posts this whenever one of its recorders takes or loses
+    /// focus. The name is not public API, but it is the only hook that fires per
+    /// field rather than per window, and per field is what this needs: recording a
+    /// combination re-registers it immediately, so anything coarser works once and
+    /// then silently stops.
+    static let recorderFocusDidChange =
+        Notification.Name("KeyboardShortcuts_recorderActiveStatusDidChange")
+
+    /// See `HotkeyManager.suspend`: a combination cannot be typed into a recorder
+    /// while it is still registered, because the system takes the key press first.
+    private func observeRecorderFocus() {
+        recorderFocusObserver = NotificationCenter.default.addObserver(
+            forName: Self.recorderFocusDidChange, object: nil, queue: .main
+        ) { [weak self] notification in
+            let isFocused = notification.userInfo?["isActive"] as? Bool ?? false
+            Task { @MainActor in
+                guard let self else { return }
+                isFocused ? self.hotkeys.suspend() : self.hotkeys.resume()
+            }
         }
     }
 
@@ -197,8 +221,8 @@ final class AppState {
 
     /// The shortcut recorder saves itself, so this is only about the effect that
     /// has on the other profiles.
-    func shortcutChanged(for profile: DictationProfile) {
-        hotkeys.claim(profile, among: profiles)
+    func shortcutChanged(to shortcut: KeyboardShortcuts.Shortcut?, for profile: DictationProfile) {
+        hotkeys.claim(shortcut, for: profile, among: profiles)
     }
 
     /// Points every monitor at the current profiles and gets each language ready.

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -28,6 +28,10 @@ final class AppState {
 
     var mainPage: MainPage = .settings
 
+    var showLanguageInHUD: Bool {
+        didSet { UserDefaults.standard.set(showLanguageInHUD, forKey: "showLanguageInHUD") }
+    }
+
     var showInDock: Bool {
         didSet {
             UserDefaults.standard.set(showInDock, forKey: "showInDock")
@@ -69,6 +73,8 @@ final class AppState {
     private var history: HistoryStore!
     private var windowCloseObserver: NSObjectProtocol?
     private let dictation: DictationSession
+    /// The profile the current dictation started in, which is what the HUD names.
+    private var activeProfile: DictationProfile
 
     private init() {
         do {
@@ -79,12 +85,14 @@ final class AppState {
 
         soundsEnabled = (UserDefaults.standard.object(forKey: "soundsEnabled") as? Bool) ?? true
         showInDock = (UserDefaults.standard.object(forKey: "showInDock") as? Bool) ?? true
+        showLanguageInHUD = (UserDefaults.standard.object(forKey: "showLanguageInHUD") as? Bool) ?? false
         cleanupEnabled = (UserDefaults.standard.object(forKey: "cleanupEnabled") as? Bool) ?? false
         currentInputName = AudioDevices.defaultInputName()
 
         // Whichever trigger fires picks the language, but something has to be
         // loaded before the first press — the first profile is the safe guess.
-        let dictation = DictationSession(locale: Self.locale(for: profileStore.profiles[0].language))
+        activeProfile = profileStore.profiles[0]
+        let dictation = DictationSession(locale: profileStore.profiles[0].locale)
         self.dictation = dictation
 
         let history = HistoryStore(context: modelContainer.mainContext)
@@ -101,7 +109,11 @@ final class AppState {
             cleaner: cleanup,
             cleanupEnabled: { [weak self] in self?.cleanupEnabled ?? false },
             vocabulary: { [weak self] in self?.vocabulary.terms ?? [] },
-            deviceName: { [weak self] in self?.currentInputName }
+            deviceName: { [weak self] in self?.currentInputName },
+            language: { [weak self] in
+                guard let self, self.showLanguageInHUD else { return nil }
+                return self.activeProfile.languageTag
+            }
         )
 
         dictation.contextualStrings = { [weak self] in self?.vocabulary.terms ?? [] }
@@ -199,7 +211,7 @@ final class AppState {
 
         // Resolving a locale and staging its model is slow enough to be felt on the
         // first press, so every language a trigger could ask for is warmed now.
-        for locale in Set(profiles.map(\.language)).map(Self.locale(for:)) {
+        for locale in Set(profiles.map(\.locale)) {
             Task.detached(priority: .utility) {
                 await DictationSession.prewarm(locale: locale)
             }
@@ -212,13 +224,10 @@ final class AppState {
     private func start(profile id: UUID) {
         guard let profile = profiles.first(where: { $0.id == id }) else { return }
         if coordinator.state == .idle {
-            dictation.setLocale(Self.locale(for: profile.language))
+            activeProfile = profile
+            dictation.setLocale(profile.locale)
         }
         Task { await coordinator.toggle() }
-    }
-
-    static func locale(for language: String) -> Locale {
-        language == DictationProfile.systemLanguage ? .current : Locale(identifier: language)
     }
 
     static func languageName(for locale: Locale) -> String {
@@ -235,7 +244,7 @@ final class AppState {
     /// away audio the user already spoke.
     func restartApp() {
         guard coordinator.state == .idle else { return }
-        hud.show(device: nil)
+        hud.show(device: nil, language: nil)
         hud.setPhase(.restarting)
         Task {
             try? await Task.sleep(nanoseconds: 900_000_000)

--- a/Sources/Coordinator/RecordingCoordinator.swift
+++ b/Sources/Coordinator/RecordingCoordinator.swift
@@ -21,6 +21,7 @@ final class RecordingCoordinator {
     private let cleanupEnabled: () -> Bool
     private let vocabulary: () -> [String]
     private let deviceName: () -> String?
+    private let language: () -> String?
 
     private var startedAt: Date?
 
@@ -37,7 +38,8 @@ final class RecordingCoordinator {
         cleaner: TranscriptCleaning,
         cleanupEnabled: @escaping () -> Bool,
         vocabulary: @escaping () -> [String],
-        deviceName: @escaping () -> String?
+        deviceName: @escaping () -> String?,
+        language: @escaping () -> String?
     ) {
         self.session = session
         self.injector = injector
@@ -48,6 +50,7 @@ final class RecordingCoordinator {
         self.cleanupEnabled = cleanupEnabled
         self.vocabulary = vocabulary
         self.deviceName = deviceName
+        self.language = language
 
         session.onLevel = { [weak self] level in self?.hud.setLevel(level) }
         session.onPartial = { [weak self] text in self?.hud.setPartial(text) }
@@ -112,7 +115,7 @@ final class RecordingCoordinator {
         state = .recording
         startedAt = Date()
         sounds.playStart()
-        hud.show(device: deviceName())
+        hud.show(device: deviceName(), language: language())
         hud.setPhase(.listening)
 
         do {

--- a/Sources/HUD/HUDController.swift
+++ b/Sources/HUD/HUDController.swift
@@ -23,11 +23,12 @@ final class HUDController: HUDControlling {
         self.panel = panel
     }
 
-    func show(device: String?) {
+    func show(device: String?, language: String?) {
         hideTask?.cancel()
 
         // Reset state BEFORE the panel is on screen, so no stale frame from the previous session is ever visible.
         model.device = device
+        model.language = language
         model.partial = ""
         model.level = 0
         model.levels = Array(repeating: 0, count: HUDModel.waveformSampleCount)

--- a/Sources/HUD/HUDControlling.swift
+++ b/Sources/HUD/HUDControlling.swift
@@ -13,7 +13,7 @@ enum HUDPhase: Equatable {
 // Behind a protocol so the coordinator can be tested without a real window.
 @MainActor
 protocol HUDControlling: AnyObject {
-    func show(device: String?)
+    func show(device: String?, language: String?)
     func setPhase(_ phase: HUDPhase)
     func setLevel(_ level: Float)
     func setPartial(_ text: String)

--- a/Sources/HUD/HUDModel.swift
+++ b/Sources/HUD/HUDModel.swift
@@ -11,6 +11,8 @@ final class HUDModel {
     var levels: [Float] = Array(repeating: 0, count: HUDModel.waveformSampleCount)
     var partial: String = ""
     var device: String?
+    // A short tag like "DE", or nil when the user would rather not see it.
+    var language: String?
 
     var onConfirm: (() -> Void)?
     var onCancel: (() -> Void)?

--- a/Sources/HUD/RecordingHUDView.swift
+++ b/Sources/HUD/RecordingHUDView.swift
@@ -11,8 +11,18 @@ struct RecordingHUDView: View {
                     .foregroundStyle(model.phase == .confirmCancel ? Theme.recording : .primary)
                     .fixedSize(horizontal: true, vertical: false)
 
+                if let language = model.language, model.phase != .restarting {
+                    LanguageTag(text: language)
+                }
+
                 if isRecordingPhase {
-                    Waveform(levels: model.levels)
+                    // The row is a fixed width, so the tag has to come out of
+                    // somewhere. A slightly shorter trace costs less than pushing
+                    // the confirm and cancel buttons off the card.
+                    Waveform(
+                        levels: model.levels,
+                        bars: model.language == nil ? Waveform.bars : Waveform.barsBesideLanguageTag
+                    )
                 }
 
                 if isProcessingPhase {
@@ -92,6 +102,23 @@ struct RecordingHUDView: View {
     }
 }
 
+/// Which language is listening, for people who dictate in more than one. Small
+/// enough to read past without noticing when there is only ever one answer.
+private struct LanguageTag: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 10, weight: .semibold))
+            .tracking(0.4)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(Color.primary.opacity(0.08)))
+            .fixedSize()
+    }
+}
+
 private struct HUDButton: View {
     let systemName: String
     var tint: Color = .secondary
@@ -125,6 +152,13 @@ private struct HUDButton: View {
 /// whole meter rising and falling as one.
 private struct Waveform: View {
     let levels: [Float]
+    /// Trimmed from the oldest end, so the newest sample stays at the right edge
+    /// however much room the rest of the row leaves.
+    let bars: Int
+
+    static let bars = HUDModel.waveformSampleCount
+    /// Ten bars is a shade more than the tag needs, so the row keeps a little slack.
+    static let barsBesideLanguageTag = HUDModel.waveformSampleCount - 10
 
     private let barWidth: CGFloat = 2.5
     private let spacing: CGFloat = 2
@@ -132,16 +166,17 @@ private struct Waveform: View {
     private let maxHeight: CGFloat = 22
 
     var body: some View {
+        let visible = Array(levels.suffix(bars))
         HStack(alignment: .center, spacing: spacing) {
-            ForEach(Array(levels.enumerated()), id: \.offset) { index, level in
+            ForEach(Array(visible.enumerated()), id: \.offset) { index, level in
                 Capsule()
-                    .fill(Color.primary.opacity(opacity(for: index)))
+                    .fill(Color.primary.opacity(opacity(for: index, of: visible.count)))
                     .frame(width: barWidth, height: height(for: level))
             }
         }
         .frame(height: maxHeight)
         // Just enough to smooth the step between samples without adding lag.
-        .animation(.easeOut(duration: 0.06), value: levels)
+        .animation(.easeOut(duration: 0.06), value: visible)
     }
 
     private func height(for level: Float) -> CGFloat {
@@ -149,9 +184,9 @@ private struct Waveform: View {
     }
 
     /// Older samples fade out, which gives the trace a sense of direction.
-    private func opacity(for index: Int) -> Double {
-        guard levels.count > 1 else { return 0.85 }
-        let age = Double(index) / Double(levels.count - 1)
+    private func opacity(for index: Int, of count: Int) -> Double {
+        guard count > 1 else { return 0.85 }
+        let age = Double(index) / Double(count - 1)
         return 0.28 + 0.57 * age
     }
 }

--- a/Sources/Models/DictationProfile.swift
+++ b/Sources/Models/DictationProfile.swift
@@ -36,4 +36,16 @@ struct DictationProfile: Codable, Identifiable, Hashable {
         self.modifierTrigger = modifierTrigger
         self.functionKeyTrigger = functionKeyTrigger
     }
+
+    /// The locale to dictate in. `systemLanguage` is resolved on read, so changing
+    /// the OS language takes effect without editing the profile.
+    var locale: Locale {
+        language == Self.systemLanguage ? .current : Locale(identifier: language)
+    }
+
+    /// A short tag like "DE" for the recording window, which has no room for
+    /// "German", let alone "German (Germany)".
+    var languageTag: String {
+        locale.language.languageCode?.identifier.uppercased() ?? language.uppercased()
+    }
 }

--- a/Sources/Models/DictationProfile.swift
+++ b/Sources/Models/DictationProfile.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// A dictation language paired with the triggers that start it. Yap keeps a list
+/// of these rather than one global language, so moving between English and German
+/// is a different key rather than a trip to Settings.
+struct DictationProfile: Codable, Identifiable, Hashable {
+    /// The name the original shortcut has always been persisted under. It predates
+    /// profiles, so the first one has to keep using it or the ⌘⇧D people already
+    /// recorded would be orphaned on upgrade.
+    static let legacyShortcutKey = "toggleRecording"
+
+    /// Follows the OS locale, whatever that turns out to be at the time.
+    static let systemLanguage = "system"
+
+    let id: UUID
+    /// `systemLanguage`, or a BCP-47 identifier.
+    var language: String
+    /// KeyboardShortcuts persists combos by name, so the name has to survive edits
+    /// to the profile — hence a stored key rather than one derived on the fly.
+    let shortcutKey: String
+    var modifierTrigger: ModifierTrigger
+    var functionKeyTrigger: FunctionKeyTrigger
+
+    init(
+        id: UUID = UUID(),
+        language: String = DictationProfile.systemLanguage,
+        shortcutKey: String? = nil,
+        modifierTrigger: ModifierTrigger = .none,
+        functionKeyTrigger: FunctionKeyTrigger = .none
+    ) {
+        self.id = id
+        self.language = language
+        // KeyboardShortcuts reads the name as a key path, so it must not contain a
+        // dot. UUIDs never do.
+        self.shortcutKey = shortcutKey ?? "dictation-\(id.uuidString)"
+        self.modifierTrigger = modifierTrigger
+        self.functionKeyTrigger = functionKeyTrigger
+    }
+}

--- a/Sources/Services/DictationProfileStore.swift
+++ b/Sources/Services/DictationProfileStore.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Observation
+
+/// The user's dictation profiles, persisted as a small JSON array so they survive
+/// launches without pulling in a database. There is always at least one — a Yap
+/// with no way to start it is a Yap that does nothing.
+@MainActor
+@Observable
+final class DictationProfileStore {
+    private static let key = "dictationProfiles"
+
+    private(set) var profiles: [DictationProfile]
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if let data = defaults.data(forKey: Self.key),
+           let decoded = try? JSONDecoder().decode([DictationProfile].self, from: data),
+           !decoded.isEmpty {
+            profiles = decoded
+        } else {
+            profiles = [Self.migrated(from: defaults)]
+            persist()
+        }
+    }
+
+    func add() {
+        profiles.append(DictationProfile())
+        persist()
+    }
+
+    func remove(_ id: UUID) {
+        guard profiles.count > 1 else { return }
+        profiles.removeAll { $0.id == id }
+        persist()
+    }
+
+    /// Two profiles sharing a trigger would race for the same press, so claiming
+    /// one takes it from whoever held it, the way the system's own shortcut
+    /// pickers do. `.none` is "unset" rather than a trigger, so it is never taken.
+    func update(_ profile: DictationProfile) {
+        guard let index = profiles.firstIndex(where: { $0.id == profile.id }) else { return }
+
+        for other in profiles.indices where other != index {
+            if profile.modifierTrigger != .none, profiles[other].modifierTrigger == profile.modifierTrigger {
+                profiles[other].modifierTrigger = .none
+            }
+            if profile.functionKeyTrigger != .none, profiles[other].functionKeyTrigger == profile.functionKeyTrigger {
+                profiles[other].functionKeyTrigger = .none
+            }
+        }
+
+        profiles[index] = profile
+        persist()
+    }
+
+    /// Yap used to have one language and one set of triggers, each in its own key.
+    /// Fold them into the first profile so upgrading is invisible. The old keys are
+    /// left where they are, so downgrading still finds them.
+    private static func migrated(from defaults: UserDefaults) -> DictationProfile {
+        DictationProfile(
+            language: defaults.string(forKey: "dictationLanguage") ?? DictationProfile.systemLanguage,
+            shortcutKey: DictationProfile.legacyShortcutKey,
+            modifierTrigger: ModifierTrigger(
+                rawValue: defaults.string(forKey: "modifierTrigger") ?? ""
+            ) ?? .none,
+            functionKeyTrigger: FunctionKeyTrigger(
+                rawValue: defaults.string(forKey: "functionKeyTrigger") ?? ""
+            ) ?? .none
+        )
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(profiles) else { return }
+        defaults.set(data, forKey: Self.key)
+    }
+}

--- a/Sources/Services/DictationSession.swift
+++ b/Sources/Services/DictationSession.swift
@@ -30,20 +30,22 @@ final class DictationSession: DictationSessioning {
         case unsupported
     }
 
-    /// Resolved once — querying supported locales is slow enough to be felt on
-    /// the first keypress.
-    private static var cachedResolution: Resolution?
+    /// Resolved once per locale — querying supported locales is slow enough to be
+    /// felt on the first keypress. Kept per locale rather than as a single slot so
+    /// that a profile for each language stays warm; alternating between them would
+    /// otherwise re-resolve on every switch.
+    private static var cachedResolutions: [String: Resolution] = [:]
 
     init(locale: Locale = .current) {
         self.locale = locale
     }
 
-    /// Switch dictation language while idle. Clears the resolved cache so the
-    /// next recording re-resolves for the new locale.
+    /// Switch dictation language while idle. The transcriber is bound to the old
+    /// locale, so it goes; the resolutions are keyed by locale and can stay.
     func setLocale(_ newLocale: Locale) {
+        guard newLocale != locale else { return }
         locale = newLocale
         transcriber = nil
-        Self.cachedResolution = nil
     }
 
     static func resolve(for locale: Locale) async -> Resolution {
@@ -55,7 +57,7 @@ final class DictationSession: DictationSessioning {
 
     static func prewarm(locale: Locale = .current) async {
         let resolution = await resolve(for: locale)
-        cachedResolution = resolution
+        cachedResolutions[locale.identifier] = resolution
         guard case .supported(let resolved) = resolution else { return }
         await TranscriptionService.prepareModel(for: resolved)
     }
@@ -74,11 +76,11 @@ final class DictationSession: DictationSessioning {
         try capture.start()
 
         let resolution: Resolution
-        if let cached = Self.cachedResolution {
+        if let cached = Self.cachedResolutions[locale.identifier] {
             resolution = cached
         } else {
             resolution = await Self.resolve(for: locale)
-            Self.cachedResolution = resolution
+            Self.cachedResolutions[locale.identifier] = resolution
         }
 
         guard case .supported(let engineLocale) = resolution else {

--- a/Sources/Services/FunctionKeyMonitor.swift
+++ b/Sources/Services/FunctionKeyMonitor.swift
@@ -9,7 +9,7 @@ import Carbon.HIToolbox
 /// dictation before any hotkey fires. So this uses a CGEvent tap at the HID
 /// level, inserted at the head of the chain, which sees the press before the
 /// system does and consumes it so the built-in action never triggers.
-enum FunctionKeyTrigger: String, CaseIterable, Identifiable {
+enum FunctionKeyTrigger: String, Codable, CaseIterable, Identifiable {
     case none
     case dictation
     case f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12
@@ -59,14 +59,27 @@ enum FunctionKeyTrigger: String, CaseIterable, Identifiable {
         guard !isRepeat, trigger.keyCodes.contains(keyCode) else { return false }
         return flags.intersection([.maskCommand, .maskAlternate, .maskControl, .maskShift]).isEmpty
     }
+
+    /// The profile whose function key was pressed, if any. One tap serves every
+    /// profile, so the press has to be matched against all of them.
+    static func match(
+        bindings: [(id: UUID, trigger: FunctionKeyTrigger)],
+        keyCode: Int64,
+        flags: CGEventFlags,
+        isRepeat: Bool
+    ) -> UUID? {
+        bindings.first {
+            shouldFire(trigger: $0.trigger, keyCode: keyCode, flags: flags, isRepeat: isRepeat)
+        }?.id
+    }
 }
 
 @MainActor
 final class FunctionKeyMonitor {
-    var trigger: FunctionKeyTrigger = .none {
+    var bindings: [(id: UUID, trigger: FunctionKeyTrigger)] = [] {
         didSet { sync() }
     }
-    var onTap: (() -> Void)?
+    var onTap: ((UUID) -> Void)?
 
     private var tap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
@@ -77,12 +90,12 @@ final class FunctionKeyMonitor {
 
     /// The tap only exists while a trigger is configured. No key trigger, no
     /// keyboard tap — Yap should not be in the key event path at all unless
-    /// the user asked for it.
+    /// the user asked for it. One tap covers every profile.
     private func sync() {
-        if trigger == .none {
-            uninstall()
-        } else {
+        if bindings.contains(where: { $0.trigger != .none }) {
             install()
+        } else {
+            uninstall()
         }
     }
 
@@ -149,15 +162,15 @@ final class FunctionKeyMonitor {
         let isRepeat = event.getIntegerValueField(.keyboardEventAutorepeat) != 0
         // The tap's run-loop source is scheduled on the main loop, so this
         // callback is already on the main thread — assumeIsolated, don't sync.
-        let shouldFire = MainActor.assumeIsolated {
-            FunctionKeyTrigger.shouldFire(
-                trigger: trigger, keyCode: keyCode, flags: event.flags, isRepeat: isRepeat
+        let matched = MainActor.assumeIsolated {
+            FunctionKeyTrigger.match(
+                bindings: bindings, keyCode: keyCode, flags: event.flags, isRepeat: isRepeat
             )
         }
 
-        guard shouldFire else { return Unmanaged.passUnretained(event) }
+        guard let matched else { return Unmanaged.passUnretained(event) }
 
-        DispatchQueue.main.async { [weak self] in self?.onTap?() }
+        DispatchQueue.main.async { [weak self] in self?.onTap?(matched) }
         // Swallow it: for the dictation key this is what keeps macOS's own
         // dictation from popping up alongside Yap.
         return nil

--- a/Sources/Services/HotkeyManager.swift
+++ b/Sources/Services/HotkeyManager.swift
@@ -40,14 +40,41 @@ final class HotkeyManager {
     /// profiles, so two can end up on one combination — which would start and then
     /// instantly stop. Whoever recorded it last keeps it, as with the other
     /// triggers, and the rest are cleared.
-    func claim(_ profile: DictationProfile, among profiles: [DictationProfile]) {
-        guard let shortcut = KeyboardShortcuts.getShortcut(for: profile.shortcutName) else { return }
-        for other in profiles where other.id != profile.id {
-            if KeyboardShortcuts.getShortcut(for: other.shortcutName) == shortcut {
-                KeyboardShortcuts.setShortcut(nil, for: other.shortcutName)
-            }
+    ///
+    /// Takes the combination the recorder reports rather than reading it back:
+    /// the callback runs before the new value reaches defaults, so a read here
+    /// would still see the old one.
+    func claim(
+        _ shortcut: KeyboardShortcuts.Shortcut?,
+        for profile: DictationProfile,
+        among profiles: [DictationProfile]
+    ) {
+        guard let shortcut else { return }
+        let taken = Self.conflicts(with: shortcut, for: profile, among: profiles) {
+            KeyboardShortcuts.getShortcut(for: $0.shortcutName)
         }
+        for other in taken { KeyboardShortcuts.setShortcut(nil, for: other.shortcutName) }
     }
+
+    /// The profiles holding a combination that someone else has just claimed.
+    static func conflicts(
+        with shortcut: KeyboardShortcuts.Shortcut,
+        for profile: DictationProfile,
+        among profiles: [DictationProfile],
+        shortcutFor: (DictationProfile) -> KeyboardShortcuts.Shortcut?
+    ) -> [DictationProfile] {
+        profiles.filter { $0.id != profile.id && shortcutFor($0) == shortcut }
+    }
+
+    /// A registered combination is claimed system-wide: the OS routes it to the
+    /// hotkey rather than delivering a key press to the app. So the recorder in
+    /// Settings never sees the keys, stays empty, and saves nil — which looks
+    /// exactly like typing a taken shortcut doing nothing. Pausing is not enough;
+    /// the combinations have to come off the system while Settings has focus,
+    /// which is also the one moment nobody wants them firing.
+    func suspend() { KeyboardShortcuts.disable(bound) }
+
+    func resume() { KeyboardShortcuts.enable(bound) }
 
     /// Forgets a removed profile's combination, so it does not linger in defaults
     /// waiting for a later profile to inherit a shortcut nobody set for it.

--- a/Sources/Services/HotkeyManager.swift
+++ b/Sources/Services/HotkeyManager.swift
@@ -1,17 +1,59 @@
+import Foundation
 import KeyboardShortcuts
 
 extension KeyboardShortcuts.Name {
     static let toggleRecording = Self("toggleRecording", default: .init(.d, modifiers: [.command, .shift]))
 }
 
+extension DictationProfile {
+    /// The first profile keeps the name the shortcut has always been stored under,
+    /// which is what carries both the recorded combination and the ⌘⇧D default
+    /// across the upgrade. Later profiles get a name of their own.
+    var shortcutName: KeyboardShortcuts.Name {
+        shortcutKey == DictationProfile.legacyShortcutKey ? .toggleRecording : .init(shortcutKey)
+    }
+}
+
 @MainActor
 final class HotkeyManager {
-    private var handler: (() -> Void)?
+    private var handler: ((UUID) -> Void)?
+    private var bound: [KeyboardShortcuts.Name] = []
 
-    func onToggle(_ action: @escaping () -> Void) {
-        handler = action
-        KeyboardShortcuts.onKeyDown(for: .toggleRecording) { [weak self] in
-            self?.handler?()
+    /// Rebinds every profile's key combination. Handlers accumulate rather than
+    /// replace, so the previous ones have to go first or a press would fire twice.
+    func bind(_ profiles: [DictationProfile], onToggle: @escaping (UUID) -> Void) {
+        handler = onToggle
+
+        for name in bound { KeyboardShortcuts.removeHandler(for: name) }
+        bound = []
+
+        for profile in profiles {
+            let id = profile.id
+            KeyboardShortcuts.onKeyDown(for: profile.shortcutName) { [weak self] in
+                self?.handler?(id)
+            }
+            bound.append(profile.shortcutName)
         }
+    }
+
+    /// The recorder writes straight to defaults and knows nothing about the other
+    /// profiles, so two can end up on one combination — which would start and then
+    /// instantly stop. Whoever recorded it last keeps it, as with the other
+    /// triggers, and the rest are cleared.
+    func claim(_ profile: DictationProfile, among profiles: [DictationProfile]) {
+        guard let shortcut = KeyboardShortcuts.getShortcut(for: profile.shortcutName) else { return }
+        for other in profiles where other.id != profile.id {
+            if KeyboardShortcuts.getShortcut(for: other.shortcutName) == shortcut {
+                KeyboardShortcuts.setShortcut(nil, for: other.shortcutName)
+            }
+        }
+    }
+
+    /// Forgets a removed profile's combination, so it does not linger in defaults
+    /// waiting for a later profile to inherit a shortcut nobody set for it.
+    func forget(_ profile: DictationProfile) {
+        KeyboardShortcuts.removeHandler(for: profile.shortcutName)
+        KeyboardShortcuts.setShortcut(nil, for: profile.shortcutName)
+        bound.removeAll { $0 == profile.shortcutName }
     }
 }

--- a/Sources/Services/ModifierHotkeyMonitor.swift
+++ b/Sources/Services/ModifierHotkeyMonitor.swift
@@ -3,7 +3,7 @@ import Carbon.HIToolbox
 
 /// Carbon hotkeys always require a real key alongside modifiers, so a bare
 /// modifier can't be one — we watch `flagsChanged` for a clean tap instead.
-enum ModifierTrigger: String, CaseIterable, Identifiable {
+enum ModifierTrigger: String, Codable, CaseIterable, Identifiable {
     case none
     case rightShift, leftShift
     case rightCommand, leftCommand
@@ -58,20 +58,65 @@ enum ModifierTrigger: String, CaseIterable, Identifiable {
 
 /// "Clean tap" means pressed and released quickly on its own — so holding
 /// Right Shift to type a capital letter never fires the trigger.
-@MainActor
-final class ModifierHotkeyMonitor {
-    var trigger: ModifierTrigger = .none {
-        didSet { reset() }
-    }
-    var onTap: (() -> Void)?
+///
+/// Kept apart from the monitor below so the rules can be tested without
+/// synthesizing NSEvents. State is per key: two profiles can bind Left and Right
+/// Option, and both can be down at once.
+struct ModifierTapRecognizer {
+    var bindings: [(id: UUID, trigger: ModifierTrigger)] = []
 
     /// Longer than this and it was a hold, not a tap.
     private let maximumTapDuration: TimeInterval = 0.6
 
+    private var held: [UInt16: (pressedAt: Date, dirty: Bool)] = [:]
+
+    /// Returns the profile whose modifier was just tapped cleanly, if any.
+    mutating func flagsChanged(
+        keyCode: UInt16, flags: NSEvent.ModifierFlags, at now: Date
+    ) -> UUID? {
+        // Another modifier moved while ours was held — that's a combo, not a tap.
+        for key in held.keys where key != keyCode { held[key]?.dirty = true }
+
+        guard let binding = bindings.first(where: { $0.trigger.keyCode == keyCode }),
+              let flag = binding.trigger.flag
+        else { return nil }
+
+        if flags.contains(flag) {
+            held[keyCode] = (pressedAt: now, dirty: false)
+            return nil
+        }
+
+        guard let press = held.removeValue(forKey: keyCode), !press.dirty else { return nil }
+        guard now.timeIntervalSince(press.pressedAt) < maximumTapDuration else { return nil }
+
+        // Anything still held means the user was building a combination. Left and
+        // Right Option share a flag, so this also covers releasing one of a pair.
+        guard flags.intersection(.deviceIndependentFlagsMask).isEmpty else { return nil }
+        return binding.id
+    }
+
+    /// A key or mouse press arrived, so nothing currently held is a bare tap.
+    mutating func interrupted() {
+        for key in held.keys { held[key]?.dirty = true }
+    }
+
+    mutating func reset() {
+        held.removeAll()
+    }
+}
+
+@MainActor
+final class ModifierHotkeyMonitor {
+    var bindings: [(id: UUID, trigger: ModifierTrigger)] = [] {
+        didSet {
+            recognizer.bindings = bindings
+            recognizer.reset()
+        }
+    }
+    var onTap: ((UUID) -> Void)?
+
+    private var recognizer = ModifierTapRecognizer()
     private var monitors: [Any] = []
-    private var isHolding = false
-    private var usedInCombination = false
-    private var pressedAt: Date?
 
     func start() {
         stop()
@@ -79,18 +124,18 @@ final class ModifierHotkeyMonitor {
         // Global monitors observe other apps; local ones cover Yap's own windows.
         addGlobal(matching: .flagsChanged) { [weak self] event in self?.handleFlags(event) }
         addGlobal(matching: [.keyDown, .leftMouseDown, .rightMouseDown]) { [weak self] _ in
-            self?.usedInCombination = true
+            self?.recognizer.interrupted()
         }
         addLocal(matching: .flagsChanged) { [weak self] event in self?.handleFlags(event) }
         addLocal(matching: [.keyDown, .leftMouseDown, .rightMouseDown]) { [weak self] _ in
-            self?.usedInCombination = true
+            self?.recognizer.interrupted()
         }
     }
 
     func stop() {
         for monitor in monitors { NSEvent.removeMonitor(monitor) }
         monitors.removeAll()
-        reset()
+        recognizer.reset()
     }
 
     private func addGlobal(matching mask: NSEvent.EventTypeMask, handler: @escaping (NSEvent) -> Void) {
@@ -110,40 +155,10 @@ final class ModifierHotkeyMonitor {
         }
     }
 
-    private func reset() {
-        isHolding = false
-        usedInCombination = false
-        pressedAt = nil
-    }
-
     private func handleFlags(_ event: NSEvent) {
-        guard let keyCode = trigger.keyCode, let flag = trigger.flag else { return }
-
-        guard event.keyCode == keyCode else {
-            // A different modifier moved while ours was held — that's a combo.
-            if isHolding { usedInCombination = true }
-            return
-        }
-
-        let isDown = event.modifierFlags.contains(flag)
-        if isDown {
-            isHolding = true
-            usedInCombination = false
-            pressedAt = Date()
-            return
-        }
-
-        guard isHolding else { return }
-        isHolding = false
-        let heldFor = pressedAt.map { Date().timeIntervalSince($0) } ?? .greatestFiniteMagnitude
-        pressedAt = nil
-
-        let noModifiersRemain = event.modifierFlags
-            .intersection(.deviceIndependentFlagsMask)
-            .isEmpty
-
-        if !usedInCombination, heldFor < maximumTapDuration, noModifiersRemain {
-            onTap?()
-        }
+        let tapped = recognizer.flagsChanged(
+            keyCode: event.keyCode, flags: event.modifierFlags, at: Date()
+        )
+        if let tapped { onTap?(tapped) }
     }
 }

--- a/Sources/Views/OnboardingView.swift
+++ b/Sources/Views/OnboardingView.swift
@@ -90,9 +90,14 @@ struct OnboardingView: View {
     }
 
     private var footnote: String {
-        app.permissions.allGranted
-            ? "You're all set. Press ⌘⇧D to start."
-            : "Grant all four to start dictating. No restart needed."
+        guard app.permissions.allGranted else {
+            return "Grant all four to start dictating. No restart needed."
+        }
+        // The shortcut is rebindable, so name whatever is actually bound.
+        guard let trigger = app.firstTriggerDescription else {
+            return "You're all set. Choose a shortcut in Settings to start."
+        }
+        return "You're all set. Press \(trigger) to start."
     }
 }
 

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -11,8 +11,7 @@ struct SettingsView: View {
             VStack(alignment: .leading, spacing: Theme.s5) {
                 historySection
                 dictionarySection
-                shortcutSection
-                languageSection
+                dictationSection
                 generalSection
                 inputSection
                 if !app.permissions.allGranted {
@@ -85,82 +84,39 @@ struct SettingsView: View {
         .buttonStyle(.plain)
     }
 
-    private var shortcutSection: some View {
-        @Bindable var app = app
-        return VStack(alignment: .leading, spacing: Theme.s3) {
-            SectionLabel("Shortcut")
-            Card(padding: Theme.s2) {
-                VStack(spacing: 0) {
-                    HStack(spacing: Theme.s3) {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Toggle dictation").font(.system(size: 13, weight: .medium))
-                            Text("Press once to start, again to stop.")
-                                .font(.system(size: 12)).foregroundStyle(.secondary)
-                        }
-                        Spacer(minLength: Theme.s3)
-                        KeyboardShortcuts.Recorder(for: .toggleRecording)
-                    }
-                    .padding(.horizontal, Theme.s3)
-                    .padding(.vertical, Theme.s2 + 2)
-
-                    Divider().overlay(Theme.hairline).padding(.horizontal, Theme.s3)
-
-                    HStack(spacing: Theme.s3) {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Single modifier key").font(.system(size: 13, weight: .medium))
-                            Text("Tap a modifier on its own, like Right Shift.")
-                                .font(.system(size: 12)).foregroundStyle(.secondary)
-                        }
-                        Spacer(minLength: Theme.s3)
-                        Picker("", selection: $app.modifierTrigger) {
-                            ForEach(ModifierTrigger.allCases) { trigger in
-                                Text(trigger.title).tag(trigger)
-                            }
-                        }
-                        .labelsHidden()
-                        .frame(width: 168)
-                    }
-                    .padding(.horizontal, Theme.s3)
-                    .padding(.vertical, Theme.s2 + 2)
-
-                    Divider().overlay(Theme.hairline).padding(.horizontal, Theme.s3)
-
-                    HStack(spacing: Theme.s3) {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Function-row key").font(.system(size: 13, weight: .medium))
-                            Text("Press an F-key, or the mic key, on its own.")
-                                .font(.system(size: 12)).foregroundStyle(.secondary)
-                        }
-                        Spacer(minLength: Theme.s3)
-                        Picker("", selection: $app.functionKeyTrigger) {
-                            ForEach(FunctionKeyTrigger.allCases) { trigger in
-                                Text(trigger.title).tag(trigger)
-                            }
-                        }
-                        .labelsHidden()
-                        .frame(width: 168)
-                    }
-                    .padding(.horizontal, Theme.s3)
-                    .padding(.vertical, Theme.s2 + 2)
+    /// One card per language. Only the first carries the explanatory subtitles —
+    /// repeating them on every card buries the settings they describe.
+    private var dictationSection: some View {
+        VStack(alignment: .leading, spacing: Theme.s3) {
+            SectionLabel("Dictation")
+            ForEach(Array(app.profiles.enumerated()), id: \.element.id) { index, profile in
+                profileCard(profile, isFirst: index == 0)
+            }
+            Button {
+                app.addProfile()
+            } label: {
+                HStack(spacing: Theme.s2) {
+                    Image(systemName: "plus").font(.system(size: 11, weight: .semibold))
+                    Text("Add a language")
                 }
             }
+            .buttonStyle(GhostButtonStyle())
+            Text("Each language gets its own triggers, so a different key dictates in a different language. Two languages cannot share one trigger.")
+                .font(.system(size: 12))
+                .foregroundStyle(.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 
-    private var languageSection: some View {
-        @Bindable var app = app
-        return VStack(alignment: .leading, spacing: Theme.s3) {
-            SectionLabel("Language")
-            Card(padding: Theme.s2) {
-                HStack(spacing: Theme.s3) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Dictation language").font(.system(size: 13, weight: .medium))
-                        Text("Dictate in a language other than your system's.")
-                            .font(.system(size: 12)).foregroundStyle(.secondary)
-                    }
-                    Spacer(minLength: Theme.s3)
-                    Picker("", selection: $app.dictationLanguage) {
-                        Text("System default").tag(AppState.systemLanguage)
+    private func profileCard(_ profile: DictationProfile, isFirst: Bool) -> some View {
+        Card(padding: Theme.s2) {
+            VStack(spacing: 0) {
+                DictationRow(
+                    title: "Language",
+                    subtitle: isFirst ? "Dictate in a language other than your system's." : nil
+                ) {
+                    Picker("", selection: binding(profile, \.language)) {
+                        Text("System default").tag(DictationProfile.systemLanguage)
                         if !app.availableLocales.isEmpty {
                             Divider()
                             ForEach(app.availableLocales, id: \.identifier) { locale in
@@ -171,11 +127,92 @@ struct SettingsView: View {
                     }
                     .labelsHidden()
                     .frame(width: 168)
+                    // The first card is the one Yap falls back to, so it stays.
+                    removeSlot(isFirst ? nil : profile)
                 }
-                .padding(.horizontal, Theme.s3)
-                .padding(.vertical, Theme.s2 + 2)
+
+                Divider().overlay(Theme.hairline).padding(.horizontal, Theme.s3)
+
+                DictationRow(
+                    title: "Toggle dictation",
+                    subtitle: isFirst ? "Press once to start, again to stop." : nil
+                ) {
+                    KeyboardShortcuts.Recorder(for: profile.shortcutName) { _ in
+                        app.shortcutChanged(for: profile)
+                    }
+                    removeSlot(nil)
+                }
+
+                Divider().overlay(Theme.hairline).padding(.horizontal, Theme.s3)
+
+                DictationRow(
+                    title: "Single modifier key",
+                    subtitle: isFirst ? "Tap a modifier on its own, like Right Shift." : nil
+                ) {
+                    Picker("", selection: binding(profile, \.modifierTrigger)) {
+                        ForEach(ModifierTrigger.allCases) { trigger in
+                            Text(trigger.title).tag(trigger)
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(width: 168)
+                    removeSlot(nil)
+                }
+
+                Divider().overlay(Theme.hairline).padding(.horizontal, Theme.s3)
+
+                DictationRow(
+                    title: "Function-row key",
+                    subtitle: isFirst ? "Press an F-key, or the mic key, on its own." : nil
+                ) {
+                    Picker("", selection: binding(profile, \.functionKeyTrigger)) {
+                        ForEach(FunctionKeyTrigger.allCases) { trigger in
+                            Text(trigger.title).tag(trigger)
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(width: 168)
+                    removeSlot(nil)
+                }
             }
         }
+    }
+
+    /// Reserved on every row, filled on one, so the controls stay in a single
+    /// column whether or not the card can be removed.
+    private func removeSlot(_ profile: DictationProfile?) -> some View {
+        Group {
+            if let profile {
+                Button {
+                    app.removeProfile(profile.id)
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("Remove this language")
+            } else {
+                Color.clear
+            }
+        }
+        .frame(width: 12)
+    }
+
+    /// Profiles are edited through the store rather than in place, so each control
+    /// writes its one field back into a copy.
+    private func binding<Value>(
+        _ profile: DictationProfile,
+        _ field: WritableKeyPath<DictationProfile, Value>
+    ) -> Binding<Value> {
+        Binding(
+            get: { profile[keyPath: field] },
+            set: { newValue in
+                var updated = profile
+                updated[keyPath: field] = newValue
+                app.updateProfile(updated)
+            }
+        )
     }
 
     private var generalSection: some View {
@@ -281,6 +318,29 @@ struct SettingsView: View {
             Text("MIT licensed")
                 .font(.system(size: 11)).foregroundStyle(.tertiary)
         }
+    }
+}
+
+/// Same hand-rolled label as `SettingsToggleRow`, for the rows whose control is a
+/// picker or a shortcut recorder rather than a switch.
+private struct DictationRow<Control: View>: View {
+    let title: String
+    var subtitle: String?
+    @ViewBuilder var control: Control
+
+    var body: some View {
+        HStack(alignment: .center, spacing: Theme.s3) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title).font(.system(size: 13, weight: .medium))
+                if let subtitle {
+                    Text(subtitle).font(.system(size: 12)).foregroundStyle(.secondary)
+                }
+            }
+            Spacer(minLength: Theme.s3)
+            control
+        }
+        .padding(.horizontal, Theme.s3)
+        .padding(.vertical, Theme.s2 + 2)
     }
 }
 

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -237,6 +237,12 @@ struct SettingsView: View {
                     )
                     Divider().overlay(Theme.hairline).padding(.horizontal, Theme.s3)
                     SettingsToggleRow(
+                        title: "Show language while recording",
+                        subtitle: "Tag the recording window with the language it is listening in.",
+                        isOn: $app.showLanguageInHUD
+                    )
+                    Divider().overlay(Theme.hairline).padding(.horizontal, Theme.s3)
+                    SettingsToggleRow(
                         title: "Sound feedback",
                         subtitle: "Play a cue when recording starts and stops.",
                         isOn: $app.soundsEnabled

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -137,8 +137,8 @@ struct SettingsView: View {
                     title: "Toggle dictation",
                     subtitle: isFirst ? "Press once to start, again to stop." : nil
                 ) {
-                    KeyboardShortcuts.Recorder(for: profile.shortcutName) { _ in
-                        app.shortcutChanged(for: profile)
+                    KeyboardShortcuts.Recorder(for: profile.shortcutName) { shortcut in
+                        app.shortcutChanged(to: shortcut, for: profile)
                     }
                     removeSlot(nil)
                 }

--- a/Tests/DictationProfileStoreTests.swift
+++ b/Tests/DictationProfileStoreTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Testing
+@testable import Yap
+
+@MainActor
+struct DictationProfileStoreTests {
+    private func isolatedDefaults() -> UserDefaults {
+        UserDefaults(suiteName: "yap.profiles.test.\(UUID().uuidString)")!
+    }
+
+    @Test func migratesTheOldSingleLanguageSettings() {
+        let defaults = isolatedDefaults()
+        defaults.set("de-DE", forKey: "dictationLanguage")
+        defaults.set(ModifierTrigger.rightOption.rawValue, forKey: "modifierTrigger")
+        defaults.set(FunctionKeyTrigger.f6.rawValue, forKey: "functionKeyTrigger")
+
+        let store = DictationProfileStore(defaults: defaults)
+
+        #expect(store.profiles.count == 1)
+        #expect(store.profiles[0].language == "de-DE")
+        #expect(store.profiles[0].modifierTrigger == .rightOption)
+        #expect(store.profiles[0].functionKeyTrigger == .f6)
+        // Keeping the old name is what carries the combo the user already recorded.
+        #expect(store.profiles[0].shortcutKey == DictationProfile.legacyShortcutKey)
+    }
+
+    @Test func leavesTheOldKeysInPlaceForADowngrade() {
+        let defaults = isolatedDefaults()
+        defaults.set("de-DE", forKey: "dictationLanguage")
+
+        _ = DictationProfileStore(defaults: defaults)
+
+        #expect(defaults.string(forKey: "dictationLanguage") == "de-DE")
+    }
+
+    @Test func startsFromOneSystemLanguageProfileOnAFreshInstall() {
+        let store = DictationProfileStore(defaults: isolatedDefaults())
+
+        #expect(store.profiles.count == 1)
+        #expect(store.profiles[0].language == DictationProfile.systemLanguage)
+        #expect(store.profiles[0].modifierTrigger == .none)
+        #expect(store.profiles[0].functionKeyTrigger == .none)
+    }
+
+    @Test func persistsAcrossReload() {
+        let defaults = isolatedDefaults()
+        let store = DictationProfileStore(defaults: defaults)
+        store.add()
+        var second = store.profiles[1]
+        second.language = "fr-FR"
+        store.update(second)
+
+        let reloaded = DictationProfileStore(defaults: defaults)
+
+        #expect(reloaded.profiles.map(\.language) == [DictationProfile.systemLanguage, "fr-FR"])
+        #expect(reloaded.profiles[1].id == second.id)
+    }
+
+    @Test func claimingATriggerTakesItFromTheProfileThatHeldIt() {
+        let store = DictationProfileStore(defaults: isolatedDefaults())
+        var first = store.profiles[0]
+        first.modifierTrigger = .rightOption
+        first.functionKeyTrigger = .f6
+        store.update(first)
+
+        store.add()
+        var second = store.profiles[1]
+        second.modifierTrigger = .rightOption
+        second.functionKeyTrigger = .f6
+        store.update(second)
+
+        #expect(store.profiles[0].modifierTrigger == .none)
+        #expect(store.profiles[0].functionKeyTrigger == .none)
+        #expect(store.profiles[1].modifierTrigger == .rightOption)
+        #expect(store.profiles[1].functionKeyTrigger == .f6)
+    }
+
+    @Test func offIsUnsetSoEveryProfileMayHoldIt() {
+        let store = DictationProfileStore(defaults: isolatedDefaults())
+        var first = store.profiles[0]
+        first.modifierTrigger = .rightOption
+        store.update(first)
+
+        store.add()
+        store.update(store.profiles[1]) // both triggers still .none
+
+        #expect(store.profiles[0].modifierTrigger == .rightOption)
+    }
+
+    @Test func refusesToRemoveTheLastProfile() {
+        let store = DictationProfileStore(defaults: isolatedDefaults())
+
+        store.remove(store.profiles[0].id)
+
+        #expect(store.profiles.count == 1)
+    }
+
+    @Test func removesAnExtraProfile() {
+        let store = DictationProfileStore(defaults: isolatedDefaults())
+        store.add()
+        let removed = store.profiles[1].id
+
+        store.remove(removed)
+
+        #expect(store.profiles.count == 1)
+        #expect(!store.profiles.contains { $0.id == removed })
+    }
+
+    @Test func givesEveryNewProfileItsOwnShortcutName() {
+        let store = DictationProfileStore(defaults: isolatedDefaults())
+        store.add()
+        store.add()
+
+        let keys = store.profiles.map(\.shortcutKey)
+        #expect(Set(keys).count == keys.count)
+        // KeyboardShortcuts uses the name in a key path and rejects dots.
+        #expect(!keys.contains { $0.contains(".") })
+    }
+}

--- a/Tests/DictationProfileTests.swift
+++ b/Tests/DictationProfileTests.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Testing
+@testable import Yap
+
+struct DictationProfileTests {
+    @Test func resolvesABCP47LanguageToItsLocale() {
+        #expect(DictationProfile(language: "de-DE").locale == Locale(identifier: "de-DE"))
+    }
+
+    @Test func followsTheSystemLocaleLate() {
+        // Resolved on read, so changing the OS language needs no edit to the profile.
+        #expect(DictationProfile().locale == .current)
+    }
+
+    @Test func shortensTheLanguageToATagForTheRecordingWindow() {
+        #expect(DictationProfile(language: "de-DE").languageTag == "DE")
+        #expect(DictationProfile(language: "fr-CH").languageTag == "FR")
+        #expect(DictationProfile(language: "en-US").languageTag == "EN")
+    }
+}

--- a/Tests/FunctionKeyTriggerTests.swift
+++ b/Tests/FunctionKeyTriggerTests.swift
@@ -54,4 +54,25 @@ struct FunctionKeyTriggerTests {
             trigger: .none, keyCode: Int64(kVK_F5), flags: [], isRepeat: false
         ))
     }
+
+    @Test func matchesThePressToItsOwnProfile() {
+        let english = UUID()
+        let german = UUID()
+        let bindings = [(id: english, trigger: FunctionKeyTrigger.f6), (id: german, trigger: .f7)]
+
+        #expect(FunctionKeyTrigger.match(
+            bindings: bindings, keyCode: Int64(kVK_F6), flags: [], isRepeat: false
+        ) == english)
+        #expect(FunctionKeyTrigger.match(
+            bindings: bindings, keyCode: Int64(kVK_F7), flags: [], isRepeat: false
+        ) == german)
+    }
+
+    @Test func matchesNothingWhenNoProfileWantsTheKey() {
+        let bindings = [(id: UUID(), trigger: FunctionKeyTrigger.f6), (id: UUID(), trigger: .none)]
+
+        #expect(FunctionKeyTrigger.match(
+            bindings: bindings, keyCode: Int64(kVK_F9), flags: [], isRepeat: false
+        ) == nil)
+    }
 }

--- a/Tests/HotkeyManagerTests.swift
+++ b/Tests/HotkeyManagerTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import KeyboardShortcuts
+import Testing
+@testable import Yap
+
+@MainActor
+struct HotkeyManagerTests {
+    private let english = DictationProfile(language: "en-US")
+    private let german = DictationProfile(language: "de-DE")
+
+    private let toggle = KeyboardShortcuts.Shortcut(.d, modifiers: [.command, .shift])
+    private let other = KeyboardShortcuts.Shortcut(.e, modifiers: [.command, .shift])
+
+    @Test func takesTheCombinationFromTheProfileThatHeldIt() {
+        let taken = HotkeyManager.conflicts(
+            with: toggle, for: german, among: [english, german]
+        ) { $0.id == english.id ? toggle : nil }
+
+        #expect(taken.map(\.id) == [english.id])
+    }
+
+    @Test func leavesProfilesOnAnotherCombinationAlone() {
+        let taken = HotkeyManager.conflicts(
+            with: toggle, for: german, among: [english, german]
+        ) { $0.id == english.id ? other : nil }
+
+        #expect(taken.isEmpty)
+    }
+
+    /// Drives the real library rather than a stub, so a change in how it stores
+    /// shortcuts by name shows up here rather than as a dead picker.
+    @Test func clearsTheOtherProfileHoldingTheSameCombination() {
+        KeyboardShortcuts.setShortcut(toggle, for: english.shortcutName)
+        KeyboardShortcuts.setShortcut(toggle, for: german.shortcutName)
+        defer {
+            KeyboardShortcuts.setShortcut(nil, for: english.shortcutName)
+            KeyboardShortcuts.setShortcut(nil, for: german.shortcutName)
+        }
+
+        HotkeyManager().claim(toggle, for: german, among: [english, german])
+
+        #expect(KeyboardShortcuts.getShortcut(for: english.shortcutName) == nil)
+        #expect(KeyboardShortcuts.getShortcut(for: german.shortcutName) == toggle)
+    }
+
+    @Test func neverTakesACombinationFromItself() {
+        // Re-recording the same combination on the same profile must not clear it.
+        let taken = HotkeyManager.conflicts(
+            with: toggle, for: english, among: [english, german]
+        ) { _ in toggle }
+
+        #expect(taken.map(\.id) == [german.id])
+    }
+}

--- a/Tests/ModifierTapRecognizerTests.swift
+++ b/Tests/ModifierTapRecognizerTests.swift
@@ -1,0 +1,109 @@
+import AppKit
+import Foundation
+import Testing
+@testable import Yap
+
+struct ModifierTapRecognizerTests {
+    private let english = UUID()
+    private let german = UUID()
+
+    private func recognizer(
+        _ bindings: [(id: UUID, trigger: ModifierTrigger)]
+    ) -> ModifierTapRecognizer {
+        var recognizer = ModifierTapRecognizer()
+        recognizer.bindings = bindings
+        return recognizer
+    }
+
+    private func code(_ trigger: ModifierTrigger) -> UInt16 { trigger.keyCode! }
+
+    private let start = Date(timeIntervalSinceReferenceDate: 0)
+    private func later(_ seconds: TimeInterval) -> Date {
+        Date(timeIntervalSinceReferenceDate: seconds)
+    }
+
+    @Test func aCleanTapFiresItsProfile() {
+        var recognizer = recognizer([(english, .rightOption)])
+
+        #expect(recognizer.flagsChanged(keyCode: code(.rightOption), flags: .option, at: start) == nil)
+        #expect(recognizer.flagsChanged(
+            keyCode: code(.rightOption), flags: [], at: later(0.1)
+        ) == english)
+    }
+
+    @Test func holdingPastTheTapWindowDoesNotFire() {
+        // A long hold is someone typing a capital letter, not reaching for Yap.
+        var recognizer = recognizer([(english, .rightShift)])
+
+        _ = recognizer.flagsChanged(keyCode: code(.rightShift), flags: .shift, at: start)
+        #expect(recognizer.flagsChanged(
+            keyCode: code(.rightShift), flags: [], at: later(0.9)
+        ) == nil)
+    }
+
+    @Test func aKeyPressDuringTheHoldDoesNotFire() {
+        var recognizer = recognizer([(english, .rightShift)])
+
+        _ = recognizer.flagsChanged(keyCode: code(.rightShift), flags: .shift, at: start)
+        recognizer.interrupted()
+        #expect(recognizer.flagsChanged(
+            keyCode: code(.rightShift), flags: [], at: later(0.1)
+        ) == nil)
+    }
+
+    @Test func anotherModifierMovingDuringTheHoldDoesNotFire() {
+        var recognizer = recognizer([(english, .rightOption)])
+
+        _ = recognizer.flagsChanged(keyCode: code(.rightOption), flags: .option, at: start)
+        _ = recognizer.flagsChanged(
+            keyCode: code(.leftCommand), flags: [.option, .command], at: later(0.05)
+        )
+        #expect(recognizer.flagsChanged(
+            keyCode: code(.rightOption), flags: .command, at: later(0.1)
+        ) == nil)
+    }
+
+    @Test func eachProfileFiresOnItsOwnModifier() {
+        var recognizer = recognizer([(english, .rightOption), (german, .leftOption)])
+
+        _ = recognizer.flagsChanged(keyCode: code(.rightOption), flags: .option, at: start)
+        #expect(recognizer.flagsChanged(
+            keyCode: code(.rightOption), flags: [], at: later(0.1)
+        ) == english)
+
+        _ = recognizer.flagsChanged(keyCode: code(.leftOption), flags: .option, at: later(1))
+        #expect(recognizer.flagsChanged(
+            keyCode: code(.leftOption), flags: [], at: later(1.1)
+        ) == german)
+    }
+
+    @Test func holdingBothBoundModifiersFiresNeither() {
+        // Left and right Option share the .option flag, so releasing one leaves the
+        // flag set — the tap is not clean and neither profile should start.
+        var recognizer = recognizer([(english, .rightOption), (german, .leftOption)])
+
+        _ = recognizer.flagsChanged(keyCode: code(.rightOption), flags: .option, at: start)
+        _ = recognizer.flagsChanged(keyCode: code(.leftOption), flags: .option, at: later(0.05))
+        #expect(recognizer.flagsChanged(
+            keyCode: code(.leftOption), flags: .option, at: later(0.1)
+        ) == nil)
+        #expect(recognizer.flagsChanged(
+            keyCode: code(.rightOption), flags: [], at: later(0.15)
+        ) == nil)
+    }
+
+    @Test func unboundModifiersNeverFire() {
+        var recognizer = recognizer([(english, .rightOption)])
+
+        _ = recognizer.flagsChanged(keyCode: code(.leftControl), flags: .control, at: start)
+        #expect(recognizer.flagsChanged(
+            keyCode: code(.leftControl), flags: [], at: later(0.1)
+        ) == nil)
+    }
+
+    @Test func offNeverFires() {
+        var recognizer = recognizer([(english, .none)])
+
+        #expect(recognizer.flagsChanged(keyCode: 0, flags: [], at: start) == nil)
+    }
+}

--- a/Tests/RecorderFocusTests.swift
+++ b/Tests/RecorderFocusTests.swift
@@ -1,0 +1,37 @@
+import AppKit
+import KeyboardShortcuts
+import Testing
+@testable import Yap
+
+@MainActor
+struct RecorderFocusTests {
+    /// Yap takes its key combinations off the system while a recorder has focus:
+    /// a registered combination is claimed system-wide, so it never reaches the
+    /// field and the field clears itself instead. That hangs off a notification
+    /// KeyboardShortcuts posts but does not declare public, so pin it here. If a
+    /// dependency bump renames it, this fails rather than the feature going quiet.
+    @Test func theLibraryStillAnnouncesRecorderFocus() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 240, height: 44),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        let recorder = KeyboardShortcuts.RecorderCocoa(for: .init("yapRecorderFocusTest"))
+        window.contentView?.addSubview(recorder)
+
+        var announced: [Bool] = []
+        let observer = NotificationCenter.default.addObserver(
+            forName: AppState.recorderFocusDidChange, object: nil, queue: nil
+        ) { notification in
+            announced.append(notification.userInfo?["isActive"] as? Bool ?? false)
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        // Taking focus resets before it activates, so it is the latest value that
+        // matters — which is all the observer in AppState reads too.
+        #expect(window.makeFirstResponder(recorder))
+        #expect(announced.last == true)
+
+        #expect(window.makeFirstResponder(nil))
+        #expect(announced.last == false)
+    }
+}

--- a/Tests/RecordingCoordinatorTests.swift
+++ b/Tests/RecordingCoordinatorTests.swift
@@ -37,10 +37,14 @@ final class FakeHUD: HUDControlling {
     var phases: [HUDPhase] = []
     var shown = 0
     var hidden = 0
+    var languages: [String?] = []
     var onConfirm: (() -> Void)?
     var onCancel: (() -> Void)?
 
-    func show(device: String?) { shown += 1 }
+    func show(device: String?, language: String?) {
+        shown += 1
+        languages.append(language)
+    }
     func setPhase(_ phase: HUDPhase) { phases.append(phase) }
     func setLevel(_ level: Float) {}
     func setPartial(_ text: String) {}
@@ -76,7 +80,8 @@ private func makeCoordinator(
     hud: FakeHUD? = nil,
     cleaner: FakeCleaner? = nil,
     cleanupEnabled: Bool = false,
-    vocabulary: [String] = []
+    vocabulary: [String] = [],
+    language: String? = nil
 ) -> RecordingCoordinator {
     RecordingCoordinator(
         session: session ?? FakeSession(),
@@ -87,7 +92,8 @@ private func makeCoordinator(
         cleaner: cleaner ?? FakeCleaner(),
         cleanupEnabled: { cleanupEnabled },
         vocabulary: { vocabulary },
-        deviceName: { "Test Mic" }
+        deviceName: { "Test Mic" },
+        language: { language }
     )
 }
 
@@ -96,6 +102,20 @@ struct RecordingCoordinatorTests {
     @Test func startsIdle() {
         let coordinator = makeCoordinator()
         #expect(coordinator.state == .idle)
+    }
+
+    @Test func handsTheHUDTheLanguageItIsListeningIn() async {
+        let hud = FakeHUD()
+        let coordinator = makeCoordinator(hud: hud, language: "DE")
+        await coordinator.toggle()
+        #expect(hud.languages == ["DE"])
+    }
+
+    @Test func leavesTheLanguageOffTheHUDWhenItIsTurnedOff() async {
+        let hud = FakeHUD()
+        let coordinator = makeCoordinator(hud: hud, language: nil)
+        await coordinator.toggle()
+        #expect(hud.languages == [nil])
     }
 
     @Test func toggleStartsRecording() async {


### PR DESCRIPTION
I came accross the same need as #15 and tried to fix it.

The README says `yap` shouldn't have too much features. I really like how fast `yap` is to install and use. It's near-perfect, but I use 3 languages daily so I would really like to have this feature.

Let me know if this PR needs more work.

Disclaimer: Claude Opus 5 has done most of the work here, but I think it makes mostly sense. I have tested the feature and it works nicely from my side.

Couple screenshots:

<img width="830" height="1402" alt="Screenshot 2026-08-05 at 14 00 28" src="https://github.com/user-attachments/assets/255926a2-2b85-4fe8-9276-239511204390" />

<img width="416" height="130" alt="Screenshot 2026-08-05 at 14 00 44" src="https://github.com/user-attachments/assets/96a509db-2d66-436a-b017-916398268260" />



Here's Claude summary for a bit more details:

> Closes #15.
> 
> Settings now holds a list of dictation profiles — a language plus the shortcut, modifier tap and function-row key that start it. Whichever trigger fires picks the language for that dictation. Optionally the recording window shows a short tag like `DE`, off by default.
> 
> **Migration.** Existing settings fold into the first profile, which keeps the name the shortcut has always been stored under, so a recorded combination carries over untouched. The old keys stay put for a downgrade, and nothing changes until you add a second language.
> 
> **Conflicts.** Two profiles can't share a trigger — claiming one takes it from whoever held it. Key combinations needed unregistering while a recorder has focus, since a registered combination is claimed system-wide and never reaches the field. The hook is a notification the library posts but doesn't declare `public`; a test pins it so a dependency bump fails loudly rather than quietly restoring the bug.
> 
> **Worth flagging:** the issue's `⇧ + Right ⌥` isn't expressible today — Carbon hotkeys need a real key, and the modifier-tap monitor only fires on a clean tap with nothing else held. Each language needs a distinct trigger instead (Right ⌥ / Left ⌥). Happy to follow up with combo support if you'd want it.
> 
> **Two that look like scope creep but aren't:**
> - The resolved-locale cache was a single slot cleared on every language change, so alternating between two languages re-resolved on each switch — the exact lag the cache exists to avoid. Now keyed by locale.
> - `OnboardingView` hardcoded "Press ⌘⇧D to start"; it now reads whatever is bound. Happy to drop this one.
> 
> `ModifierHotkeyMonitor`'s state couldn't represent two modifiers held at once, so the clean-tap rules moved into a pure `ModifierTapRecognizer`, mirroring the existing `FunctionKeyTrigger.shouldFire`. `RecordingCoordinator` is otherwise untouched — it takes the language tag through a closure alongside `deviceName`. With the tag on, the HUD's waveform gives up its oldest ten bars rather than push the buttons off the fixed-width card.
> 
> **Verification.** 90 tests in 15 suites. Exercised by hand over a real 0.1.9 install: settings migrated with the shortcut intact, two languages dictate from two keys, and combinations move between languages correctly.