### PR TITLE
fix: crash when switching to a device with a different sample rate

### DIFF
--- a/Sources/Services/AudioCaptureService.swift
+++ b/Sources/Services/AudioCaptureService.swift
@@ -8,7 +8,7 @@ final class AudioCaptureService {
     /// Called on the audio thread with a normalized 0...1 level.
     var onLevel: ((Float) -> Void)?
 
-    private let engine = AVAudioEngine()
+    private var engine = AVAudioEngine()
     private(set) var isRunning = false
     private var configObserver: NSObjectProtocol?
     private var handlingConfigChange = false
@@ -19,6 +19,13 @@ final class AudioCaptureService {
         // several handlers would race to rebuild the graph on the next device
         // change.
         removeConfigObserver()
+
+        // Build a new engine every time. A reused one keeps the format of the
+        // device it last ran on, so installTap gets a 48 kHz format on a 16 kHz
+        // Bluetooth mic and throws an Objective-C exception. Swift cannot catch
+        // that, and the unwind corrupts the task state enough to crash the app.
+        engine = AVAudioEngine()
+
         installTap()
         addConfigObserver()
 


### PR DESCRIPTION
### Tested the crash and fixed version with these 2 inputs:

MacBook Pro Microphone, 48kHz
OnePlus Nord Buds 3 Pro, 16kHz


### Reproducing the crash:

Keep using macbook's mic, type something with it

then change input device from macos settings to one with a different sample rate

press Super+Shift+D again, say something and then submit (crashes when you click on submit)

### Crash log:

```
[avae] AVAEUtility.mm:176  Format mismatch: input hw <1 ch, 16000 Hz, Float32>,
                           client format <1 ch, 48000 Hz, Float32>
[General] Failed to create tap due to format mismatch, <1 ch, 48000 Hz, Float32>
[General] 1  libobjc.A.dylib  objc_exception_throw + 88
[General] 3  AVFAudio         AVAudioEngineGraph::InstallTapOnNode + 600
[General] 4  AVFAudio         -[AVAudioNode installTapOnBus:bufferSize:format:error:block:] + 456
[General] 5  Yap              AudioCaptureService.installTap()
[General] 6  Yap              AudioCaptureService.start()
[General] 7  Yap              DictationSession.start()          <- async, exception unwinds out
[General] 8  Yap              RecordingCoordinator.startRecording()
[HIExceptions] FAULT: com.apple.coreaudio.avfaudio: Failed to create tap due to format mismatch

-- app is still running, but then the next button tap anywhere in the UI leads to: --

thread #50, name = 'Task 550', queue = 'com.apple.main-thread'
stop reason = EXC_BAD_ACCESS (code=1, address=0x1e)
  objc_opt_class
  swift_getObjectType
  swift_task_isMainExecutorImpl
  swift_task_isCurrentExecutorWithFlagsImpl
  MainActor.assumeIsolated
  closure #1 in _ButtonGesture.internalBody
```


