### PR TITLE
Add a "Show in menu bar" toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ So Yap ships no model at all. It's roughly three thousand lines of native Swift 
 - Press escape twice to discard a dictation in progress
 - Follows your system default microphone, including when it changes mid-session
 - Optional launch at login, off by default
+- Lives in the menu bar, the Dock, both, or neither — hide either icon from Settings and run on the shortcut alone
 - No account, no network calls, no telemetry
 
 ## Requirements

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -48,6 +48,13 @@ final class AppState {
         }
     }
 
+    /// With this and `showInDock` both off, Yap runs on the shortcut alone and puts
+    /// nothing on screen. Opening it again from Spotlight or Finder is the way back:
+    /// `applicationShouldHandleReopen` surfaces a window without launching a second copy.
+    var showInMenuBar: Bool {
+        didSet { UserDefaults.standard.set(showInMenuBar, forKey: "showInMenuBar") }
+    }
+
     /// "system" follows the OS locale; otherwise a BCP-47 identifier.
     var dictationLanguage: String {
         didSet {
@@ -88,6 +95,7 @@ final class AppState {
 
         soundsEnabled = (UserDefaults.standard.object(forKey: "soundsEnabled") as? Bool) ?? true
         showInDock = (UserDefaults.standard.object(forKey: "showInDock") as? Bool) ?? true
+        showInMenuBar = (UserDefaults.standard.object(forKey: "showInMenuBar") as? Bool) ?? true
         cleanupEnabled = (UserDefaults.standard.object(forKey: "cleanupEnabled") as? Bool) ?? false
         modifierTrigger = ModifierTrigger(
             rawValue: UserDefaults.standard.string(forKey: "modifierTrigger") ?? ""

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -195,8 +195,18 @@ struct SettingsView: View {
                     Divider().overlay(Theme.hairline).padding(.horizontal, Theme.s3)
                     SettingsToggleRow(
                         title: "Show in Dock",
-                        subtitle: "Turn off to run from the menu bar only.",
+                        subtitle: app.showInMenuBar
+                            ? "Turn off to run from the menu bar only."
+                            : "The menu bar icon is off too, so open Yap from Spotlight to get back here.",
                         isOn: $app.showInDock
+                    )
+                    Divider().overlay(Theme.hairline).padding(.horizontal, Theme.s3)
+                    SettingsToggleRow(
+                        title: "Show in menu bar",
+                        subtitle: app.showInDock
+                            ? "Turn off to run from the Dock only."
+                            : "The Dock icon is off too, so open Yap from Spotlight to get back here.",
+                        isOn: $app.showInMenuBar
                     )
                     Divider().overlay(Theme.hairline).padding(.horizontal, Theme.s3)
                     SettingsToggleRow(

--- a/Sources/YapApp.swift
+++ b/Sources/YapApp.swift
@@ -23,7 +23,7 @@ struct YapApp: App {
     private var isRecording: Bool { app.coordinator.state != .idle }
 
     var body: some Scene {
-        MenuBarExtra {
+        MenuBarExtra(isInserted: $app.showInMenuBar) {
             Button(isRecording ? "Stop Dictation" : "Start Dictation") {
                 app.toggleRecording()
             }


### PR DESCRIPTION
Closes #28.

Adds a "Show in menu bar" row next to "Show in Dock" in Settings, persisted in `UserDefaults` and on by default. The hiding itself is `MenuBarExtra(isInserted:)`.

Turning both off is allowed rather than guarded against: Yap then runs on the shortcut alone, and opening it from Spotlight or Finder brings a window back through `applicationShouldHandleReopen`. Each row says so once the other icon is off.